### PR TITLE
CMake improvements and PKG-Config Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,12 +109,12 @@ IF (${BIDIB_USE_TESTS})
 	IF (CMAKE_BUILD_TYPE MATCHES "Debug")
 		SET(COVERAGE_TEST_DIR coverage_test)
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
-		SET(BIDIB_STATIC_FILENAME $<TARGET_FILE_NAME:bidib_static>)
+		LIST(GET UNIT_TESTS 0 RANDOM_UNIT_TEST)
 
 		ADD_CUSTOM_TARGET(coverage_test
 			COMMAND ${LLVM_PROFDATA} merge ${COVERAGE_TEST_DIR}/*.profraw
 			        -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
-			COMMAND ${LLVM_COV} show -format=html -output-dir=${COVERAGE_TEST_DIR} ${BIDIB_STATIC_FILENAME}
+			COMMAND ${LLVM_COV} show -format=html -output-dir=${COVERAGE_TEST_DIR} ${RANDOM_UNIT_TEST}
 			        -instr-profile=${COVERAGE_TEST_DIR}/coverage_test.profdata -show-line-counts-or-regions
 			DEPENDS ${UNIT_TESTS}
 		)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,11 +109,12 @@ IF (${BIDIB_USE_TESTS})
 	IF (CMAKE_BUILD_TYPE MATCHES "Debug")
 		SET(COVERAGE_TEST_DIR coverage_test)
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+		SET(BIDIB_STATIC_FILENAME $<TARGET_FILE_NAME:bidib_static>)
 
 		ADD_CUSTOM_TARGET(coverage_test
 			COMMAND ${LLVM_PROFDATA} merge ${COVERAGE_TEST_DIR}/*.profraw
 			        -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
-			COMMAND ${LLVM_COV} show -format=html -output-dir=${COVERAGE_TEST_DIR} ${UNIT_TESTS}
+			COMMAND ${LLVM_COV} show -format=html -output-dir=${COVERAGE_TEST_DIR} ${BIDIB_STATIC_FILENAME}
 			        -instr-profile=${COVERAGE_TEST_DIR}/coverage_test.profdata -show-line-counts-or-regions
 			DEPENDS ${UNIT_TESTS}
 		)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 3.6)
 project(libbidib)
 
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS "-Wall -Wextra")
-set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+SET(CMAKE_C_STANDARD 11)
+SET(CMAKE_C_FLAGS "-Wall -Wextra")
+SET(CMAKE_EXPORT_COMPILE_COMMANDS on)
+
+SET(BIDIB_USE_TESTS true CACHE BOOL "Compile the tests")
+
+SET(CMAKE_INSTALL_INCLUDEDIR include/bidib)
+
 
 include(FindPkgConfig)
 pkg_check_modules(GLIB glib-2.0 REQUIRED)
@@ -35,58 +40,112 @@ file(GLOB SRCFILES "src/*/*.c")
 # - - - - - - - - - - - - -
 
 
-enable_testing()
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
+
+
+# - - - - - - - - - - - - -
+# INCLUDE FILES
+# - - - - - - - - - - - - -
+
+FILE(GLOB INCLUDES_MAIN "include/*.h")
+FILE(GLOB INCLUDES_DEFINITIONS "include/definitions/*.h")
+FILE(GLOB INCLUDES_HIGHLEVEL "include/highlevel/*.h")
+FILE(GLOB INCLUDES_LOWLEVEL "include/lowlevel/*.h")
+
+#message(STATUS "INCLUDES_MAIN Files: ${INCLUDES_MAIN}")
+
+
+
+# - - - - - - - - - - - - -
+# LIBRARY DEFINITION
+# - - - - - - - - - - - - -
+
+SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
 add_library(bidib_static STATIC include src ${SRCFILES})
 
 add_library(bidib SHARED include src ${SRCFILES})
 
 
-# Unit tests
-
-set(UNIT_TESTS bidib_send_tests bidib_receive_tests
-               bidib_lowlevel_message_tests bidib_config_parser_tests
-               bidib_highlevel_message_tests bidib_state_tests)
-
-foreach(UNIT_TEST ${UNIT_TESTS})
-	add_executable(${UNIT_TEST} test test/unit/${UNIT_TEST}.c)
-	target_link_libraries(${UNIT_TEST} glib-2.0 cmocka pthread yaml bidib_static)
-	add_test(${UNIT_TEST} ${UNIT_TEST})
-endforeach()
 
 
-# Code coverage
 
-if (CMAKE_BUILD_TYPE MATCHES "Debug")
-	set(COVERAGE_TEST_DIR coverage_test)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 
-	add_custom_target(coverage_test
-		COMMAND llvm-profdata merge ${COVERAGE_TEST_DIR}/*.profraw 
-			    -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
-		COMMAND llvm-cov show -format=html -output-dir=${COVERAGE_TEST_DIR} ${UNIT_TESTS}
-			    -instr-profile=${COVERAGE_TEST_DIR}/coverage_test.profdata -show-line-counts-or-regions
-		DEPENDS ${UNIT_TESTS}
-	)
+# - - - - - - - - - - - - -
+# INSTALL DEFINITION
+# - - - - - - - - - - - - -
+
+include(GNUInstallDirs)
+
+configure_file("bidib.pc.in" "bidib.pc" @ONLY)
+configure_file("bidib_static.pc.in" "bidib_static.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bidib.pc" "${CMAKE_CURRENT_BINARY_DIR}/bidib_static.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+
+install(FILES ${INCLUDES_MAIN} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${INCLUDES_DEFINITIONS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/definitions)
+install(FILES ${INCLUDES_HIGHLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highlevel)
+install(FILES ${INCLUDES_LOWLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lowlevel)
+install(TARGETS bidib bidib_static)
+
+
+
+
+
+# - - - - - - - - - - - - -
+# TESTS DEFINITION
+# - - - - - - - - - - - - -
+
+
+IF (${BIDIB_USE_TESTS})
+	enable_testing()
+
+	# Unit tests
+
+	set(UNIT_TESTS bidib_send_tests bidib_receive_tests
+	               bidib_lowlevel_message_tests bidib_config_parser_tests
+	               bidib_highlevel_message_tests bidib_state_tests)
 
 	foreach(UNIT_TEST ${UNIT_TESTS})
-		add_custom_target(${UNIT_TEST}_coverage_prepare
-			COMMAND LLVM_PROFILE_FILE=${COVERAGE_TEST_DIR}/${UNIT_TEST}.profraw $<TARGET_FILE:${UNIT_TEST}>
-			DEPENDS ${UNIT_TESTS}
-		)
-		add_dependencies(coverage_test ${UNIT_TEST}_coverage_prepare)
+		add_executable(${UNIT_TEST} test test/unit/${UNIT_TEST}.c)
+		target_link_libraries(${UNIT_TEST} glib-2.0 cmocka pthread yaml bidib_static)
+		add_test(${UNIT_TEST} ${UNIT_TEST})
 	endforeach()
 
-	unset(CMAKE_BUILD_TYPE CACHE)
-endif (CMAKE_BUILD_TYPE MATCHES "Debug")
+
+	# Code coverage
+
+	IF (CMAKE_BUILD_TYPE MATCHES "Debug")
+		set(COVERAGE_TEST_DIR coverage_test)
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+
+		add_custom_target(coverage_test
+			COMMAND llvm-profdata merge ${COVERAGE_TEST_DIR}/*.profraw 
+				    -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
+			COMMAND llvm-cov show -format=html -output-dir=${COVERAGE_TEST_DIR} ${UNIT_TESTS}
+				    -instr-profile=${COVERAGE_TEST_DIR}/coverage_test.profdata -show-line-counts-or-regions
+			DEPENDS ${UNIT_TESTS}
+		)
+
+		foreach(UNIT_TEST ${UNIT_TESTS})
+			add_custom_target(${UNIT_TEST}_coverage_prepare
+				COMMAND LLVM_PROFILE_FILE=${COVERAGE_TEST_DIR}/${UNIT_TEST}.profraw $<TARGET_FILE:${UNIT_TEST}>
+				DEPENDS ${UNIT_TESTS}
+			)
+			add_dependencies(coverage_test ${UNIT_TEST}_coverage_prepare)
+		endforeach()
+
+		unset(CMAKE_BUILD_TYPE CACHE)
+	ENDIF (CMAKE_BUILD_TYPE MATCHES "Debug")
 
 
-# Physical test
+	# Physical test
 
-add_executable(swtbahn-standard-testsuite test test/physical/swtbahn-standard/main.c test/physical/swtbahn-standard/testsuite.c)
-target_link_libraries(swtbahn-standard-testsuite glib-2.0 pthread yaml bidib_static)
+	add_executable(swtbahn-standard-testsuite test test/physical/swtbahn-standard/main.c test/physical/swtbahn-standard/testsuite.c)
+	target_link_libraries(swtbahn-standard-testsuite glib-2.0 pthread yaml bidib_static)
 
-add_executable(swtbahn-full-testsuite test test/physical/swtbahn-full/main.c test/physical/swtbahn-full/testsuite.c)
-target_link_libraries(swtbahn-full-testsuite glib-2.0 pthread yaml bidib_static)
+	add_executable(swtbahn-full-testsuite test test/physical/swtbahn-full/main.c test/physical/swtbahn-full/testsuite.c)
+	target_link_libraries(swtbahn-full-testsuite glib-2.0 pthread yaml bidib_static)
+
+ENDIF(${BIDIB_USE_TESTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,50 +10,23 @@ SET(BIDIB_USE_TESTS true CACHE BOOL "Compile the tests")
 SET(CMAKE_INSTALL_INCLUDEDIR include/bidib)
 
 
-include(FindPkgConfig)
+INCLUDE(FindPkgConfig)
 pkg_check_modules(GLIB glib-2.0 REQUIRED)
-include_directories(${GLIB_INCLUDE_DIRS})
-
-file(GLOB SRCFILES "src/*/*.c")
+INCLUDE_DIRECTORIES(${GLIB_INCLUDE_DIRS})
 
 
-# - - - - - - - - - - - - -
-# ADJUSTMENT SECTION BEGIN
-# - - - - - - - - - - - - -
-
-
-# If you have cmocka installed system wide, comment out the following six lines.
-# Otherwise adjust the paths according to your installation.
-#set(CMOCKA_DIR /home/nicolas/git/cmocka)
-#add_library(cmocka SHARED IMPORTED)
-#set_target_properties(cmocka PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-#	${CMOCKA_DIR}/include)
-#set_target_properties(cmocka PROPERTIES IMPORTED_LOCATION
-#	${CMOCKA_DIR}/bin/src/libcmocka.so.0.4.1)
-
-# You can add all other libraries which you have not installed system wide by the
-# above pattern.
-
-
-# - - - - - - - - - - - - -
-# ADJUSTMENT SECTION END
-# - - - - - - - - - - - - -
-
-
-
-
+# SRC files
+FILE(GLOB SRCFILES "src/*/*.c")
 
 # - - - - - - - - - - - - -
 # INCLUDE FILES
 # - - - - - - - - - - - - -
 
+# Collecting the headers for each folder, needed for the include targets later
 FILE(GLOB INCLUDES_MAIN "include/*.h")
 FILE(GLOB INCLUDES_DEFINITIONS "include/definitions/*.h")
 FILE(GLOB INCLUDES_HIGHLEVEL "include/highlevel/*.h")
 FILE(GLOB INCLUDES_LOWLEVEL "include/lowlevel/*.h")
-
-#message(STATUS "INCLUDES_MAIN Files: ${INCLUDES_MAIN}")
-
 
 
 # - - - - - - - - - - - - -
@@ -62,12 +35,8 @@ FILE(GLOB INCLUDES_LOWLEVEL "include/lowlevel/*.h")
 
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
-add_library(bidib_static STATIC include src ${SRCFILES})
-
-add_library(bidib SHARED include src ${SRCFILES})
-
-
-
+ADD_LIBRARY(bidib_static STATIC include src ${SRCFILES})
+ADD_LIBRARY(bidib SHARED include src ${SRCFILES})
 
 
 
@@ -75,19 +44,21 @@ add_library(bidib SHARED include src ${SRCFILES})
 # INSTALL DEFINITION
 # - - - - - - - - - - - - -
 
-include(GNUInstallDirs)
+INCLUDE(GNUInstallDirs)
 
-configure_file("bidib.pc.in" "bidib.pc" @ONLY)
-configure_file("bidib_static.pc.in" "bidib_static.pc" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bidib.pc" "${CMAKE_CURRENT_BINARY_DIR}/bidib_static.pc"
+# Configuring and install target pkgconfig files
+CONFIGURE_FILE("bidib.pc.in" "bidib.pc" @ONLY)
+CONFIGURE_FILE("bidib_static.pc.in" "bidib_static.pc" @ONLY)
+INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/bidib.pc" "${CMAKE_CURRENT_BINARY_DIR}/bidib_static.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-
-install(FILES ${INCLUDES_MAIN} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES ${INCLUDES_DEFINITIONS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/definitions)
-install(FILES ${INCLUDES_HIGHLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highlevel)
-install(FILES ${INCLUDES_LOWLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lowlevel)
-install(TARGETS bidib bidib_static)
+# Install targets for headers
+INSTALL(FILES ${INCLUDES_MAIN} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+INSTALL(FILES ${INCLUDES_DEFINITIONS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/definitions)
+INSTALL(FILES ${INCLUDES_HIGHLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highlevel)
+INSTALL(FILES ${INCLUDES_LOWLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lowlevel)
+# Install Target for libs
+INSTALL(TARGETS bidib bidib_static)
 
 
 
@@ -99,28 +70,27 @@ install(TARGETS bidib bidib_static)
 
 
 IF (${BIDIB_USE_TESTS})
-	enable_testing()
-
+	ENABLE_TESTING()
 	# Unit tests
 
-	set(UNIT_TESTS bidib_send_tests bidib_receive_tests
+	SET(UNIT_TESTS bidib_send_tests bidib_receive_tests
 	               bidib_lowlevel_message_tests bidib_config_parser_tests
 	               bidib_highlevel_message_tests bidib_state_tests)
 
-	foreach(UNIT_TEST ${UNIT_TESTS})
-		add_executable(${UNIT_TEST} test test/unit/${UNIT_TEST}.c)
-		target_link_libraries(${UNIT_TEST} glib-2.0 cmocka pthread yaml bidib_static)
-		add_test(${UNIT_TEST} ${UNIT_TEST})
-	endforeach()
+	FOREACH(UNIT_TEST ${UNIT_TESTS})
+		ADD_EXECUTABLE(${UNIT_TEST} test test/unit/${UNIT_TEST}.c)
+		TARGET_LINK_LIBRARIES(${UNIT_TEST} glib-2.0 cmocka pthread yaml bidib_static)
+		ADD_TEST(${UNIT_TEST} ${UNIT_TEST})
+	ENDFOREACH()
 
 
 	# Code coverage
 
 	IF (CMAKE_BUILD_TYPE MATCHES "Debug")
-		set(COVERAGE_TEST_DIR coverage_test)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+		SET(COVERAGE_TEST_DIR coverage_test)
+		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 
-		add_custom_target(coverage_test
+		ADD_CUSTOM_TARGET(coverage_test
 			COMMAND llvm-profdata merge ${COVERAGE_TEST_DIR}/*.profraw 
 				    -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
 			COMMAND llvm-cov show -format=html -output-dir=${COVERAGE_TEST_DIR} ${UNIT_TESTS}
@@ -128,24 +98,24 @@ IF (${BIDIB_USE_TESTS})
 			DEPENDS ${UNIT_TESTS}
 		)
 
-		foreach(UNIT_TEST ${UNIT_TESTS})
-			add_custom_target(${UNIT_TEST}_coverage_prepare
+		FOREACH(UNIT_TEST ${UNIT_TESTS})
+			ADD_CUSTOM_TARGET(${UNIT_TEST}_coverage_prepare
 				COMMAND LLVM_PROFILE_FILE=${COVERAGE_TEST_DIR}/${UNIT_TEST}.profraw $<TARGET_FILE:${UNIT_TEST}>
 				DEPENDS ${UNIT_TESTS}
 			)
-			add_dependencies(coverage_test ${UNIT_TEST}_coverage_prepare)
-		endforeach()
+			ADD_DEPENDENCIES(coverage_test ${UNIT_TEST}_coverage_prepare)
+		ENDFOREACH()
 
-		unset(CMAKE_BUILD_TYPE CACHE)
+		UNSET(CMAKE_BUILD_TYPE CACHE)
 	ENDIF (CMAKE_BUILD_TYPE MATCHES "Debug")
 
 
 	# Physical test
 
-	add_executable(swtbahn-standard-testsuite test test/physical/swtbahn-standard/main.c test/physical/swtbahn-standard/testsuite.c)
-	target_link_libraries(swtbahn-standard-testsuite glib-2.0 pthread yaml bidib_static)
+	ADD_EXECUTABLE(swtbahn-standard-testsuite test test/physical/swtbahn-standard/main.c test/physical/swtbahn-standard/testsuite.c)
+	TARGET_LINK_LIBRARIES(swtbahn-standard-testsuite glib-2.0 pthread yaml bidib_static)
 
-	add_executable(swtbahn-full-testsuite test test/physical/swtbahn-full/main.c test/physical/swtbahn-full/testsuite.c)
-	target_link_libraries(swtbahn-full-testsuite glib-2.0 pthread yaml bidib_static)
+	ADD_EXECUTABLE(swtbahn-full-testsuite test test/physical/swtbahn-full/main.c test/physical/swtbahn-full/testsuite.c)
+	TARGET_LINK_LIBRARIES(swtbahn-full-testsuite glib-2.0 pthread yaml bidib_static)
 
 ENDIF(${BIDIB_USE_TESTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,25 @@ SET(BIDIB_USE_TESTS true CACHE BOOL "Compile the tests")
 
 SET(CMAKE_INSTALL_INCLUDEDIR include/bidib)
 
-
 INCLUDE(FindPkgConfig)
 pkg_check_modules(GLIB glib-2.0 REQUIRED)
 INCLUDE_DIRECTORIES(${GLIB_INCLUDE_DIRS})
+pkg_check_modules(CMOCKA cmocka REQUIRED)
+INCLUDE_DIRECTORIES(${CMOCKA_INCLUDE_DIRS})
 
+IF (APPLE)
+	# Use the automatically found library directories
+	LINK_DIRECTORIES(${GLIB_LIBRARY_DIRS})
+	LINK_DIRECTORIES(${CMOCKA_LIBRARY_DIRS})
+
+	# Manually add the include and library directories for yaml
+	INCLUDE_DIRECTORIES(/usr/local/Cellar/libyaml/0.2.5/include)
+	LINK_DIRECTORIES(/usr/local/Cellar/libyaml/0.2.5/lib)
+ENDIF (APPLE)
 
 # SRC files
 FILE(GLOB SRCFILES "src/*/*.c")
+
 
 # - - - - - - - - - - - - -
 # INCLUDE FILES
@@ -41,34 +52,35 @@ ADD_LIBRARY(bidib SHARED include src ${SRCFILES})
 TARGET_LINK_LIBRARIES(bidib PRIVATE glib-2.0 pthread yaml)
 TARGET_LINK_LIBRARIES(bidib_static PRIVATE glib-2.0 pthread yaml)
 
+
 # - - - - - - - - - - - - -
 # INSTALL DEFINITION
 # - - - - - - - - - - - - -
 
 INCLUDE(GNUInstallDirs)
 
-# Configuring and install target pkgconfig files
+# Configure and install target pkgconfig files
 CONFIGURE_FILE("bidib.pc.in" "bidib.pc" @ONLY)
 CONFIGURE_FILE("bidib_static.pc.in" "bidib_static.pc" @ONLY)
-INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/bidib.pc" "${CMAKE_CURRENT_BINARY_DIR}/bidib_static.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+INSTALL(FILES
+	"${CMAKE_CURRENT_BINARY_DIR}/bidib.pc"
+	"${CMAKE_CURRENT_BINARY_DIR}/bidib_static.pc"
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
 
 # Install targets for headers
 INSTALL(FILES ${INCLUDES_MAIN} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 INSTALL(FILES ${INCLUDES_DEFINITIONS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/definitions)
 INSTALL(FILES ${INCLUDES_HIGHLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highlevel)
 INSTALL(FILES ${INCLUDES_LOWLEVEL} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lowlevel)
+
 # Install Target for libs
 INSTALL(TARGETS bidib bidib_static)
-
-
-
 
 
 # - - - - - - - - - - - - -
 # TESTS DEFINITION
 # - - - - - - - - - - - - -
-
 
 IF (${BIDIB_USE_TESTS})
 	ENABLE_TESTING()
@@ -86,16 +98,23 @@ IF (${BIDIB_USE_TESTS})
 
 
 	# Code coverage
+	IF (APPLE)
+		SET(LLVM_PROFDATA xcrun llvm-profdata)
+		SET(LLVM_COV xcrun llvm-cov)
+	ELSE ()
+		SET(LLVM_PROFDATA llvm-profdata)
+		SET(LLVM_COV llvm-cov)
+	ENDIF (APPLE)
 
 	IF (CMAKE_BUILD_TYPE MATCHES "Debug")
 		SET(COVERAGE_TEST_DIR coverage_test)
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 
 		ADD_CUSTOM_TARGET(coverage_test
-			COMMAND llvm-profdata merge ${COVERAGE_TEST_DIR}/*.profraw 
-				    -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
-			COMMAND llvm-cov show -format=html -output-dir=${COVERAGE_TEST_DIR} ${UNIT_TESTS}
-				    -instr-profile=${COVERAGE_TEST_DIR}/coverage_test.profdata -show-line-counts-or-regions
+			COMMAND ${LLVM_PROFDATA} merge ${COVERAGE_TEST_DIR}/*.profraw
+			        -o ${COVERAGE_TEST_DIR}/coverage_test.profdata
+			COMMAND ${LLVM_COV} show -format=html -output-dir=${COVERAGE_TEST_DIR} ${UNIT_TESTS}
+			        -instr-profile=${COVERAGE_TEST_DIR}/coverage_test.profdata -show-line-counts-or-regions
 			DEPENDS ${UNIT_TESTS}
 		)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 ADD_LIBRARY(bidib_static STATIC include src ${SRCFILES})
 ADD_LIBRARY(bidib SHARED include src ${SRCFILES})
 
-
+TARGET_LINK_LIBRARIES(bidib PRIVATE glib-2.0 pthread yaml)
+TARGET_LINK_LIBRARIES(bidib_static PRIVATE glib-2.0 pthread yaml)
 
 # - - - - - - - - - - - - -
 # INSTALL DEFINITION

--- a/bidib.pc.in
+++ b/bidib.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: Bidib library
+Version: @VERSION@
+Libs: -L${libdir} -lbidib
+Cflags: -I${includedir}
+Requires:@REQUIRES_LIBS@

--- a/bidib.pc.in
+++ b/bidib.pc.in
@@ -2,7 +2,7 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
-Description: Bidib library
+Description: BiDiB shared library
 Version: @VERSION@
 Libs: -L${libdir} -lbidib
 Cflags: -I${includedir}

--- a/bidib_static.pc.in
+++ b/bidib_static.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: Bidib_static library
+Version: @VERSION@
+Libs: -L${libdir} -lbidib_static
+Cflags: -I${includedir}
+Requires:@REQUIRES_LIBS@

--- a/bidib_static.pc.in
+++ b/bidib_static.pc.in
@@ -2,7 +2,7 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
-Description: Bidib_static library
+Description: BiDiB static library
 Version: @VERSION@
 Libs: -L${libdir} -lbidib_static
 Cflags: -I${includedir}

--- a/src/highlevel/bidib_highlevel_setter.c
+++ b/src/highlevel/bidib_highlevel_setter.c
@@ -113,6 +113,7 @@ int bidib_switch_point(const char *point, const char *aspect) {
 					return 1;
 				}
 				t_bidib_node_address tmp_addr = board_i->node_addr;
+				pthread_mutex_unlock(&bidib_state_boards_mutex);
 				t_bidib_dcc_aspect *aspect_mapping =
 						bidib_get_dcc_aspect_by_id(dcc_mapping->aspects, aspect);
 				if (aspect_mapping != NULL) {
@@ -138,7 +139,6 @@ int bidib_switch_point(const char *point, const char *aspect) {
 					                "0x%02x 0x00) to aspect: %s with action id: %d",
 					                point, board_i->id->str, tmp_addr.top, tmp_addr.sub,
 					                tmp_addr.subsub, aspect, action_id);
-					pthread_mutex_unlock(&bidib_state_boards_mutex);
 					return 0;
 				} else {
 					pthread_mutex_unlock(&bidib_state_boards_mutex);
@@ -206,6 +206,7 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 					return 1;
 				}
 				t_bidib_node_address tmp_addr = board_i->node_addr;
+				pthread_mutex_unlock(&bidib_state_boards_mutex);
 				t_bidib_dcc_aspect *aspect_mapping =
 						bidib_get_dcc_aspect_by_id(dcc_mapping->aspects, aspect);
 				if (aspect_mapping != NULL) {
@@ -231,7 +232,6 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 					                "0x%02x 0x00) to aspect: %s with action id: %d",
 					                signal, board_i->id->str, tmp_addr.top, tmp_addr.sub,
 					                tmp_addr.subsub, aspect, action_id);
-					pthread_mutex_unlock(&bidib_state_boards_mutex);
 					return 0;
 				} else {
 					pthread_mutex_unlock(&bidib_state_boards_mutex);

--- a/src/highlevel/bidib_highlevel_setter.c
+++ b/src/highlevel/bidib_highlevel_setter.c
@@ -82,7 +82,6 @@ int bidib_switch_point(const char *point, const char *aspect) {
 					return 1;
 				}
 				t_bidib_node_address tmp_addr = board_i->node_addr;
-				pthread_mutex_unlock(&bidib_state_boards_mutex);
 				t_bidib_aspect *aspect_mapping =
 						bidib_get_aspect_by_id(board_mapping->aspects, aspect);
 				if (aspect_mapping != NULL) {
@@ -93,6 +92,7 @@ int bidib_switch_point(const char *point, const char *aspect) {
 					                tmp_addr.subsub, aspect, aspect_mapping->value, action_id);
 					bidib_send_accessory_set(tmp_addr, board_mapping->number,
 					                         aspect_mapping->value, action_id);
+					pthread_mutex_unlock(&bidib_state_boards_mutex);
 					return 0;
 				} else {
 					pthread_mutex_unlock(&bidib_state_boards_mutex);
@@ -113,7 +113,6 @@ int bidib_switch_point(const char *point, const char *aspect) {
 					return 1;
 				}
 				t_bidib_node_address tmp_addr = board_i->node_addr;
-				pthread_mutex_unlock(&bidib_state_boards_mutex);
 				t_bidib_dcc_aspect *aspect_mapping =
 						bidib_get_dcc_aspect_by_id(dcc_mapping->aspects, aspect);
 				if (aspect_mapping != NULL) {
@@ -139,6 +138,7 @@ int bidib_switch_point(const char *point, const char *aspect) {
 					                "0x%02x 0x00) to aspect: %s with action id: %d",
 					                point, board_i->id->str, tmp_addr.top, tmp_addr.sub,
 					                tmp_addr.subsub, aspect, action_id);
+					pthread_mutex_unlock(&bidib_state_boards_mutex);
 					return 0;
 				} else {
 					pthread_mutex_unlock(&bidib_state_boards_mutex);
@@ -176,7 +176,6 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 					return 1;
 				}
 				t_bidib_node_address tmp_addr = board_i->node_addr;
-				pthread_mutex_unlock(&bidib_state_boards_mutex);
 				t_bidib_aspect *aspect_mapping = bidib_get_aspect_by_id(board_mapping->aspects, aspect);
 				if (aspect_mapping != NULL) {
 					unsigned int action_id = bidib_get_and_incr_action_id();
@@ -186,6 +185,7 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 					                aspect_mapping->id->str, aspect_mapping->value, action_id);
 					bidib_send_accessory_set(tmp_addr, board_mapping->number,
 					                         aspect_mapping->value, action_id);
+					pthread_mutex_unlock(&bidib_state_boards_mutex);
 					return 0;
 				} else {
 					pthread_mutex_unlock(&bidib_state_boards_mutex);
@@ -206,7 +206,6 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 					return 1;
 				}
 				t_bidib_node_address tmp_addr = board_i->node_addr;
-				pthread_mutex_unlock(&bidib_state_boards_mutex);
 				t_bidib_dcc_aspect *aspect_mapping =
 						bidib_get_dcc_aspect_by_id(dcc_mapping->aspects, aspect);
 				if (aspect_mapping != NULL) {
@@ -232,6 +231,7 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 					                "0x%02x 0x00) to aspect: %s with action id: %d",
 					                signal, board_i->id->str, tmp_addr.top, tmp_addr.sub,
 					                tmp_addr.subsub, aspect, action_id);
+					pthread_mutex_unlock(&bidib_state_boards_mutex);
 					return 0;
 				} else {
 					pthread_mutex_unlock(&bidib_state_boards_mutex);
@@ -360,14 +360,14 @@ int bidib_set_calibrated_train_speed(const char *train, int speed, const char *t
 		syslog_libbidib(LOG_ERR, "Set calibrated train speed: speed must be in range -9...9");
 		return 1;
 	}
-	
+
 	t_bidib_train *tmp_train = bidib_state_get_train_ref(train);
-	
+
 	if (tmp_train == NULL) {
 		syslog_libbidib(LOG_ERR, "Set calibrated train speed: %s train does not exist", train);
 		return 1;
 	}
-	
+
 	int error = 0;
 	if (tmp_train->calibration == NULL) {
 		syslog_libbidib(LOG_ERR, "Set calibrated train speed: no calibration for train %s", 
@@ -468,7 +468,7 @@ int bidib_set_train_peripheral(const char *train, const char *peripheral, uint8_
 		return 1;
 	}
 	pthread_mutex_lock(&bidib_state_boards_mutex);
-	
+
 	t_bidib_train *tmp_train = bidib_state_get_train_ref(train);
 	t_bidib_board *board = bidib_state_get_board_ref(track_output);
 	if (tmp_train == NULL) {

--- a/src/parser/bidib_config_parser.c
+++ b/src/parser/bidib_config_parser.c
@@ -46,11 +46,11 @@ bool bidib_config_init_parser(const char *config_dir, const char *config_file,
 	*fh = fopen(full_path, "r");
 
 	if (*fh == NULL) {
-		syslog_libbidib(LOG_ERR, "%s", "Failed to open board-config");
+		syslog_libbidib(LOG_ERR, "Failed to open %s%s", config_dir, config_file);
 		return true;
 	} else if (!yaml_parser_initialize(parser)) {
 		fclose(*fh);
-		syslog_libbidib(LOG_ERR, "%s", "Failed to initialize config parser");
+		syslog_libbidib(LOG_ERR, "Failed to initialize config parser");
 		return true;
 	}
 
@@ -211,7 +211,7 @@ bool bidib_config_parse_scalar_then_section(yaml_parser_t *parser, char *scalar,
 
 bool bidib_config_parse(const char *config_dir) {
 	if (config_dir == NULL) {
-		syslog_libbidib(LOG_INFO, "%s", 
+		syslog_libbidib(LOG_INFO,
 		                "No config loaded, because no directory submitted");
 		return false;
 	} else if (bidib_config_parse_board_config(config_dir) ||
@@ -219,6 +219,6 @@ bool bidib_config_parse(const char *config_dir) {
 	           bidib_config_parse_train_config(config_dir)) {
 		return true;
 	}
-	syslog_libbidib(LOG_INFO, "%s", "Config loaded successfully");
+	syslog_libbidib(LOG_INFO, "Config loaded successfully");
 	return false;
 }

--- a/src/parser/bidib_config_parser_intern.h
+++ b/src/parser/bidib_config_parser_intern.h
@@ -40,7 +40,7 @@
  * Reads the config files and create the track state structure.
  *
  * @param config_dir the directory containing the config files.
- * @return true if an error occurred and false if successful.
+ * @return false if successful, otherwise true.
  */
 bool bidib_config_parse(const char *config_dir);
 
@@ -51,7 +51,7 @@ bool bidib_config_parse(const char *config_dir);
  * @param config_file the name of the config file.
  * @param fh destination for the file handler.
  * @param parser destination for the parser.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 bool bidib_config_init_parser(const char *config_dir, const char *config_file,
                               FILE **fh, yaml_parser_t *parser);
@@ -61,7 +61,7 @@ bool bidib_config_init_parser(const char *config_dir, const char *config_file,
  *
  * @param string the string.
  * @param byte the destination for the byte.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 bool bidib_string_to_byte(char *string, uint8_t *byte);
 
@@ -70,7 +70,7 @@ bool bidib_string_to_byte(char *string, uint8_t *byte);
  *
  * @param string the string.
  * @param uid the destination for the unique id.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 bool bidib_string_to_uid(char *string, t_bidib_unique_id_mod *uid);
 
@@ -79,7 +79,7 @@ bool bidib_string_to_uid(char *string, t_bidib_unique_id_mod *uid);
  *
  * @param string the string.
  * @param dcc_address the destination for the dcc_address.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 bool bidib_string_to_dccaddr(char *string, t_bidib_dcc_address *dcc_address);
 
@@ -88,7 +88,7 @@ bool bidib_string_to_dccaddr(char *string, t_bidib_dcc_address *dcc_address);
  *
  * @param string the string.
  * @param port the destination of the port.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 bool bidib_string_to_port(char *string, t_bidib_peripheral_port *port);
 
@@ -98,7 +98,7 @@ bool bidib_string_to_port(char *string, t_bidib_peripheral_port *port);
  * @param parser the parser.
  * @param scalar the name of the scalar.
  * @param section_elem_action handler for an item in the section.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 bool bidib_config_parse_scalar_then_section(yaml_parser_t *parser, char *scalar,
                                             bool (*section_elem_action)(yaml_parser_t *));
@@ -107,7 +107,7 @@ bool bidib_config_parse_scalar_then_section(yaml_parser_t *parser, char *scalar,
  * Parses the board config file.
  *
  * @param config_dir the directory containing the config files.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 int bidib_config_parse_board_config(const char *config_dir);
 
@@ -115,7 +115,7 @@ int bidib_config_parse_board_config(const char *config_dir);
  * Parses the track config file.
  *
  * @param config_dir the directory containing the config files.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 int bidib_config_parse_track_config(const char *config_dir);
 
@@ -123,7 +123,7 @@ int bidib_config_parse_track_config(const char *config_dir);
  * Parses the train config file.
  *
  * @param config_dir the directory containing the config files.
- * @return true if successful, otherwise false.
+ * @return false if successful, otherwise true.
  */
 int bidib_config_parse_train_config(const char *config_dir);
 

--- a/src/parser/bidib_config_parser_track.c
+++ b/src/parser/bidib_config_parser_track.c
@@ -1050,22 +1050,18 @@ static bool bidib_config_parse_single_board_peripheral(yaml_parser_t *parser,
 		yaml_event_delete(&event);
 	}
 
-	t_bidib_peripheral_mapping tmp;
-	for (size_t i = 0; i < board->peripherals->len; i++) {
-		tmp = g_array_index(board->peripherals, t_bidib_peripheral_mapping, i);
-		if (tmp.number == mapping.number) {
-			syslog_libbidib(LOG_ERR, "Peripheral %s configured with same number "
-							"as peripheral %s", mapping.id->str, tmp.id->str);
-			error = true;
-			break;
-		}
-	}
-
 	for (size_t i = 0; i < board->peripherals->len; i++) {
 		tmp = g_array_index(board->peripherals, t_bidib_peripheral_mapping, i);
 		if (tmp.port.port0 == mapping.port.port0 &&
 		    tmp.port.port1 == mapping.port.port1) {
 			syslog_libbidib(LOG_ERR, "Peripheral %s configured with same port "
+			                "as peripheral %s", mapping.id->str, tmp.id->str);
+			error = true;
+			break;
+		}
+		
+		if (tmp.number == mapping.number) {
+			syslog_libbidib(LOG_ERR, "Peripheral %s configured with same number "
 			                "as peripheral %s", mapping.id->str, tmp.id->str);
 			error = true;
 			break;

--- a/src/parser/bidib_config_parser_track.c
+++ b/src/parser/bidib_config_parser_track.c
@@ -1050,6 +1050,7 @@ static bool bidib_config_parse_single_board_peripheral(yaml_parser_t *parser,
 		yaml_event_delete(&event);
 	}
 
+	t_bidib_peripheral_mapping tmp;
 	for (size_t i = 0; i < board->peripherals->len; i++) {
 		tmp = g_array_index(board->peripherals, t_bidib_peripheral_mapping, i);
 		if (tmp.port.port0 == mapping.port.port0 &&

--- a/src/parser/bidib_config_parser_track.c
+++ b/src/parser/bidib_config_parser_track.c
@@ -1088,7 +1088,8 @@ static bool bidib_config_parse_single_board_peripheral(yaml_parser_t *parser,
 typedef enum {
 	SEGMENT_START,
 	SEGMENT_ID_KEY, SEGMENT_ID_VALUE,
-	SEGMENT_ADDR_KEY, SEGMENT_ADDR_VALUE
+	SEGMENT_ADDR_KEY, SEGMENT_ADDR_VALUE,
+	SEGMENT_LENGTH_KEY, SEGMENT_LENGTH_VALUE
 } t_bidib_parser_segment_scalar;
 
 static bool bidib_config_parse_single_board_segment(yaml_parser_t *parser,
@@ -1134,7 +1135,7 @@ static bool bidib_config_parse_single_board_segment(yaml_parser_t *parser,
 				error = true;
 				break;
 			case YAML_MAPPING_END_EVENT:
-				if (last_scalar == SEGMENT_ADDR_VALUE) {
+				if (last_scalar == SEGMENT_LENGTH_VALUE) {
 					done = true;
 				} else {
 					error = true;
@@ -1182,6 +1183,17 @@ static bool bidib_config_parse_single_board_segment(yaml_parser_t *parser,
 						}
 						break;
 					case SEGMENT_ADDR_VALUE:
+						if (!strcmp((char *) event.data.scalar.value, "length")) {
+							last_scalar = SEGMENT_LENGTH_KEY;
+						} else {
+							error = true;
+						}
+						break;
+					case SEGMENT_LENGTH_KEY:
+						segment_state.length = g_string_new((char *) event.data.scalar.value);
+						last_scalar = SEGMENT_LENGTH_VALUE;
+						break;
+					case SEGMENT_LENGTH_VALUE:
 					//	error = true;
 						break;
 				}

--- a/src/state/bidib_state_free.c
+++ b/src/state/bidib_state_free.c
@@ -85,6 +85,9 @@ void bidib_state_free_single_segment_state_intern(t_bidib_segment_state_intern s
 	if (segment_state.id != NULL) {
 		g_string_free(segment_state.id, TRUE);
 	}
+	if (segment_state.length != NULL) {
+		g_string_free(segment_state.length, TRUE);
+	}
 	if (segment_state.dcc_addresses != NULL) {
 		g_array_free(segment_state.dcc_addresses, TRUE);
 	}
@@ -244,6 +247,7 @@ void bidib_state_free(void) {
 						              t_bidib_state_initial_value, i));
 			}
 			g_array_free(bidib_initial_values.points, TRUE);
+			bidib_initial_values.points = NULL;
 		}
 		if (bidib_initial_values.signals != NULL) {
 			for (size_t i = 0; i < bidib_initial_values.signals->len; i++) {
@@ -252,6 +256,7 @@ void bidib_state_free(void) {
 						              t_bidib_state_initial_value, i));
 			}
 			g_array_free(bidib_initial_values.signals, TRUE);
+			bidib_initial_values.signals = NULL;
 		}
 		if (bidib_initial_values.peripherals != NULL) {
 			for (size_t i = 0; i < bidib_initial_values.peripherals->len; i++) {
@@ -260,6 +265,7 @@ void bidib_state_free(void) {
 						              t_bidib_state_initial_value, i));
 			}
 			g_array_free(bidib_initial_values.peripherals, TRUE);
+			bidib_initial_values.peripherals = NULL;
 		}
 		if (bidib_initial_values.trains != NULL) {
 			for (size_t i = 0; i < bidib_initial_values.trains->len; i++) {
@@ -268,6 +274,7 @@ void bidib_state_free(void) {
 						              t_bidib_state_train_initial_value, i));
 			}
 			g_array_free(bidib_initial_values.trains, TRUE);
+			bidib_initial_values.trains = NULL;
 		}
 
 		if (bidib_track_state.points_board != NULL) {
@@ -277,6 +284,7 @@ void bidib_state_free(void) {
 						              t_bidib_board_accessory_state, i));
 			}
 			g_array_free(bidib_track_state.points_board, TRUE);
+			bidib_track_state.points_board = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.points_dcc->len; i++) {
 				bidib_state_free_single_dcc_accessory_state(
@@ -284,6 +292,7 @@ void bidib_state_free(void) {
 						              t_bidib_dcc_accessory_state, i));
 			}
 			g_array_free(bidib_track_state.points_dcc, TRUE);
+			bidib_track_state.points_dcc = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.signals_board->len; i++) {
 				bidib_state_free_single_board_accessory_state(
@@ -291,6 +300,7 @@ void bidib_state_free(void) {
 						              t_bidib_board_accessory_state, i));
 			}
 			g_array_free(bidib_track_state.signals_board, TRUE);
+			bidib_track_state.signals_board = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.signals_dcc->len; i++) {
 				bidib_state_free_single_dcc_accessory_state(
@@ -298,6 +308,7 @@ void bidib_state_free(void) {
 						              t_bidib_dcc_accessory_state, i));
 			}
 			g_array_free(bidib_track_state.signals_dcc, TRUE);
+			bidib_track_state.signals_dcc = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.peripherals->len; i++) {
 				bidib_state_free_single_peripheral_state(
@@ -305,6 +316,7 @@ void bidib_state_free(void) {
 						              t_bidib_peripheral_state, i));
 			}
 			g_array_free(bidib_track_state.peripherals, TRUE);
+			bidib_track_state.peripherals = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.segments->len; i++) {
 				bidib_state_free_single_segment_state_intern(
@@ -312,6 +324,7 @@ void bidib_state_free(void) {
 						              t_bidib_segment_state_intern, i));
 			}
 			g_array_free(bidib_track_state.segments, TRUE);
+			bidib_track_state.segments = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.trains->len; i++) {
 				bidib_state_free_single_train_state_intern(
@@ -319,6 +332,7 @@ void bidib_state_free(void) {
 						              t_bidib_train_state_intern, i));
 			}
 			g_array_free(bidib_track_state.trains, TRUE);
+			bidib_track_state.trains = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.boosters->len; i++) {
 				bidib_state_free_single_booster_state(
@@ -326,6 +340,7 @@ void bidib_state_free(void) {
 						              t_bidib_booster_state, i));
 			}
 			g_array_free(bidib_track_state.boosters, TRUE);
+			bidib_track_state.boosters = NULL;
 
 			for (size_t i = 0; i < bidib_track_state.track_outputs->len; i++) {
 				bidib_state_free_single_track_output_state(
@@ -333,6 +348,7 @@ void bidib_state_free(void) {
 						              t_bidib_track_output_state, i));
 			}
 			g_array_free(bidib_track_state.track_outputs, TRUE);
+			bidib_track_state.track_outputs = NULL;
 		}
 
 		if (bidib_boards != NULL) {
@@ -341,6 +357,7 @@ void bidib_state_free(void) {
 				                                            t_bidib_board, i));
 			}
 			g_array_free(bidib_boards, TRUE);
+			bidib_boards = NULL;
 		}
 
 		if (bidib_trains != NULL) {
@@ -349,6 +366,7 @@ void bidib_state_free(void) {
 				                                            t_bidib_train, i));
 			}
 			g_array_free(bidib_trains, TRUE);
+			bidib_trains = NULL;
 		}
 	}
 }

--- a/src/state/bidib_state_free.c
+++ b/src/state/bidib_state_free.c
@@ -260,7 +260,6 @@ void bidib_state_free(void) {
 						              t_bidib_state_initial_value, i));
 			}
 			g_array_free(bidib_initial_values.peripherals, TRUE);
-
 		}
 		if (bidib_initial_values.trains != NULL) {
 			for (size_t i = 0; i < bidib_initial_values.trains->len; i++) {

--- a/src/state/bidib_state_getter.c
+++ b/src/state/bidib_state_getter.c
@@ -307,6 +307,7 @@ t_bidib_segment_state_intern bidib_state_get_segment_state(
 		const t_bidib_segment_state_intern *segment_state) {
 	t_bidib_segment_state_intern query;
 	query.id = g_string_new(segment_state->id->str);
+	query.length = g_string_new(segment_state->length->str);
 	query.occupied = segment_state->occupied;
 	query.confidence = segment_state->confidence;
 	query.power_consumption = segment_state->power_consumption;

--- a/src/state/bidib_state_intern.h
+++ b/src/state/bidib_state_intern.h
@@ -60,6 +60,7 @@ typedef struct {
 
 typedef struct {
 	GString *id;
+	GString *length;
 	bool occupied;
 	t_bidib_segment_state_confidence confidence;
 	t_bidib_power_consumption power_consumption;

--- a/src/state/bidib_state_setter.c
+++ b/src/state/bidib_state_setter.c
@@ -44,7 +44,7 @@ void bidib_state_boost_state(t_bidib_node_address node_address, uint8_t power_st
 		booster_state->data.power_state_simple =
 				bidib_booster_normal_to_simple(booster_state->data.power_state);
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No booster configured with node address 0x%02x 0x%02x 0x%02x 0x0",
 		                node_address.top, node_address.sub, node_address.subsub);
 	}
@@ -72,7 +72,7 @@ void bidib_state_accessory_state(t_bidib_node_address node_address, uint8_t numb
 			}
 		}
 		if (accessory_state->data.state_id == NULL) {
-			syslog_libbidib(LOG_WARNING, 
+			syslog_libbidib(LOG_WARNING,
 			                "Aspect 0x%02x of accessory %s is not mapped in config files",
 			                aspect, accessory_mapping->id->str);
 		}
@@ -80,13 +80,13 @@ void bidib_state_accessory_state(t_bidib_node_address node_address, uint8_t numb
 		accessory_state->data.execution_state = (t_bidib_accessory_execution_state) execution;
 		accessory_state->data.wait_details = wait;
 		if (total < accessory_mapping->aspects->len) {
-			syslog_libbidib(LOG_ERR, 
+			syslog_libbidib(LOG_ERR,
 			                "More aspects configured in track config than on bidib board for accessory %s",
 			                accessory_mapping->id->str);
 		}
 	} else {
 		pthread_mutex_unlock(&bidib_state_boards_mutex);
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No board accessory 0x%02x configured for node address 0x%02x 0x%02x 0x%02x 0x0",
 		                number, node_address.top, node_address.sub, node_address.subsub);
 	}
@@ -108,7 +108,7 @@ void bidib_state_node_new(t_bidib_node_address node_address, uint8_t local_addr,
 		}
 		board->node_addr = node_address;
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No board configured for unique id 0x%02x%02x%02x%02x%02x%02x%02x",
 		                unique_id.class_id, unique_id.class_id_ext, unique_id.vendor_id,
 		                unique_id.product_id1, unique_id.product_id2, unique_id.product_id3,
@@ -150,7 +150,7 @@ void bidib_state_node_lost(t_bidib_unique_id_mod unique_id) {
 			}
 		}
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No board configured for unique id 0x%02x%02x%02x%02x%02x%02x%02x",
 		                unique_id.class_id, unique_id.class_id_ext, unique_id.vendor_id,
 		                unique_id.product_id1, unique_id.product_id2, unique_id.product_id3,
@@ -220,7 +220,7 @@ void bidib_state_cs_drive(t_bidib_cs_drive_mod params) {
 	t_bidib_train_peripheral_state *peripheral_state;
 	if (train_state != NULL) {
 		uint8_t function_bits[] = {params.function1, params.function2,
-		                                 params.function3, params.function4};
+		                           params.function3, params.function4};
 		if (params.active == 0x00) {
 			train_state->set_speed_step = 0;
 			for (size_t i = 0; i < train_state->peripherals->len; i++) {
@@ -289,7 +289,7 @@ void bidib_state_cs_drive(t_bidib_cs_drive_mod params) {
 		syslog_libbidib(LOG_ERR, "No train configured for dcc address 0x%02x%02x",
 		                params.dcc_address.addrh, params.dcc_address.addrl);
 		if (bidib_state_dcc_addr_in_use(params.dcc_address)) {
-			syslog_libbidib(LOG_ERR, 
+			syslog_libbidib(LOG_ERR,
 			                "Dcc address 0x%02x%02x is already in use, remove the "
 			                "unconfigured train to avoid conflicts",
 			                params.dcc_address.addrh, params.dcc_address.addrl);
@@ -309,7 +309,7 @@ void bidib_state_cs_accessory_manual(t_bidib_node_address node_address,
 	t_bidib_dcc_accessory_state *accessory_state;
 	if (accessory_mapping != NULL &&
 	    (accessory_state =
-			     bidib_state_get_dcc_accessory_state_ref(accessory_mapping->id->str, point)) != NULL) {
+				bidib_state_get_dcc_accessory_state_ref(accessory_mapping->id->str, point)) != NULL) {
 		accessory_state->data.state_value = (uint8_t) (data & 0x1F);
 		if (data & (1 << 5)) {
 			accessory_state->data.coil_on = true;
@@ -318,7 +318,7 @@ void bidib_state_cs_accessory_manual(t_bidib_node_address node_address,
 		}
 		accessory_state->data.switch_time = 0;
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No dcc accessory configured for dcc address 0x%02x%02x",
 		                dcc_address.addrh, dcc_address.addrl);
 	}
@@ -336,7 +336,7 @@ void bidib_state_cs_accessory(t_bidib_node_address node_address,
 	t_bidib_dcc_accessory_state *accessory_state;
 	if (accessory_mapping != NULL &&
 	    (accessory_state =
-			     bidib_state_get_dcc_accessory_state_ref(accessory_mapping->id->str, point)) != NULL) {
+				bidib_state_get_dcc_accessory_state_ref(accessory_mapping->id->str, point)) != NULL) {
 		accessory_state->data.state_id = NULL;
 		accessory_state->data.state_value = (uint8_t) (params.data & 0x1F);
 		if (params.data & (1 << 5)) {
@@ -356,7 +356,7 @@ void bidib_state_cs_accessory(t_bidib_node_address node_address,
 		}
 		accessory_state->data.switch_time = (uint8_t) (params.time & 0x7F);
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No dcc accessory configured for dcc address 0x%02x%02x",
 		                params.dcc_address.addrh, params.dcc_address.addrl);
 	}
@@ -380,17 +380,17 @@ void bidib_state_lc_stat(t_bidib_node_address node_address, t_bidib_peripheral_p
 			}
 		}
 		if (peripheral_state->data.state_id == NULL) {
-			syslog_libbidib(LOG_WARNING, 
+			syslog_libbidib(LOG_WARNING,
 			                "Aspect 0x%02x of peripheral %s is not mapped in config files",
 			                portstat, peripheral_mapping->id->str);
 		}
 		peripheral_state->data.state_value = portstat;
 	} else {
-		syslog_libbidib(LOG_ERR, 
-			                "No peripheral on port 0x%02x 0x%02x configured for node address "
-			                "0x%02x 0x%02x 0x%02x 0x00",
-			                port.port0, port.port1, node_address.top, 
-			                node_address.sub, node_address.subsub);
+		syslog_libbidib(LOG_ERR,
+		                "No peripheral on port 0x%02x 0x%02x configured for node address "
+		                "0x%02x 0x%02x 0x%02x 0x00",
+		                port.port0, port.port1, node_address.top,
+		                node_address.sub, node_address.subsub);
 	}
 	pthread_mutex_unlock(&bidib_state_track_mutex);
 }
@@ -410,10 +410,10 @@ void bidib_state_lc_wait(t_bidib_node_address node_address, t_bidib_peripheral_p
 		}
 		peripheral_state->data.wait = (uint8_t) (time & 0x7F);
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No peripheral on port 0x%02x 0x%02x configured for node address "
 		                "0x%02x 0x%02x 0x%02x 0x00",
-		                port.port0, port.port1, node_address.top, 
+		                port.port0, port.port1, node_address.top,
 		                node_address.sub, node_address.subsub);
 	}
 	pthread_mutex_unlock(&bidib_state_track_mutex);
@@ -425,26 +425,26 @@ void bidib_state_log_train_detect(bool detected, t_bidib_dcc_address *dcc_addres
 		bidib_state_get_train_state_ref_by_dccaddr(*dcc_address);
 	if (detected) {
 		if (train_state == NULL) {
-			syslog_libbidib(LOG_NOTICE, 
+			syslog_libbidib(LOG_NOTICE,
 			                "Segment: %s is being entered by: unknown train (0x%02x%02x) with %s orientation",
 			                segment_state->id->str, dcc_address->addrh, dcc_address->addrl,
 			                dcc_address->type == 0 ? "left" : "right");
 		} else {
-			syslog_libbidib(LOG_NOTICE, 
+			syslog_libbidib(LOG_NOTICE,
 			                "Segment: %s is being entered by: %s with %s orientation",
 			                segment_state->id->str, train_state->id->str,
 			                train_state->orientation == BIDIB_TRAIN_ORIENTATION_LEFT ? "left" : "right");
 		}
 	} else {
 		if (train_state == NULL) {
-			syslog_libbidib(LOG_NOTICE, 
+			syslog_libbidib(LOG_NOTICE,
 			                "Segment: %s is being exited by: unknown train (0x%02x%02x) with %s orientation",
-			                segment_state->id->str, dcc_address->addrh, dcc_address->addrl, 
+			                segment_state->id->str, dcc_address->addrh, dcc_address->addrl,
 			                dcc_address->type == 0 ? "left" : "right");
 		} else {
-			syslog_libbidib(LOG_NOTICE, 
+			syslog_libbidib(LOG_NOTICE,
 			                "Segment: %s is being exited by: %s with %s orientation",
-			                segment_state->id->str, train_state->id->str, 
+			                segment_state->id->str, train_state->id->str,
 			                train_state->orientation == BIDIB_TRAIN_ORIENTATION_LEFT ? "left" : "right");
 		}
 	}
@@ -469,7 +469,7 @@ void bidib_state_bm_occ(t_bidib_node_address node_address, uint8_t number, bool 
 		}
 		bidib_state_update_train_available();
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No segment with number 0x%02x configured for node address "
 		                "0x%02x 0x%02x 0x%02x 0x0",
 		                number, node_address.top, node_address.sub, node_address.subsub);
@@ -542,7 +542,7 @@ void bidib_state_bm_confidence(t_bidib_node_address node_address, uint8_t conf_v
 			}
 		}
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No board configured for node address 0x%02x 0x%02x 0x%02x 0x0",
 		                node_address.top, node_address.sub, node_address.subsub);
 	}
@@ -551,7 +551,7 @@ void bidib_state_bm_confidence(t_bidib_node_address node_address, uint8_t conf_v
 }
 
 void bidib_state_bm_address_log_changes(
-		t_bidib_segment_state_intern *segment_state_intern_query,
+        t_bidib_segment_state_intern *segment_state_intern_query,
         uint8_t address_count, uint8_t *addresses) {
 	t_bidib_dcc_address *dcc_address_old;
 	t_bidib_dcc_address dcc_address_new;
@@ -567,9 +567,9 @@ void bidib_state_bm_address_log_changes(
 				// http://bidib.org/protokoll/bidib_occ_e.html#T-addressformat
 				dcc_address_new.addrl = addresses[i * 2];
 				dcc_address_new.addrh = (uint8_t) (addresses[(i * 2) + 1] & 0x3F);
-				dcc_address_new.type = (addresses[(i * 2) + 1] >> 6) & 0x03;				
+				dcc_address_new.type = (addresses[(i * 2) + 1] >> 6) & 0x03;
 				for (size_t j = 0; j < dcc_addresses_old->len; j++) {
-					dcc_address_old = 
+					dcc_address_old =
 							&g_array_index(dcc_addresses_old, t_bidib_dcc_address, j);
 					if (dcc_address_old->addrl == dcc_address_new.addrl &&
 					    dcc_address_old->addrh == dcc_address_new.addrh) {
@@ -590,7 +590,7 @@ void bidib_state_bm_address_log_changes(
 	// check for lost addresses
 	bool still_in_segment = false;
 	for (size_t i = 0; i < dcc_addresses_old->len; i++) {
-		dcc_address_old = 
+		dcc_address_old =
 				&g_array_index(dcc_addresses_old, t_bidib_dcc_address, i);
 		for (size_t j = 0; j < address_count; j++) {
 			dcc_address_new.addrl = addresses[j * 2];
@@ -617,7 +617,7 @@ void bidib_state_bm_address(t_bidib_node_address node_address, uint8_t number,
 			bidib_state_get_segment_state_ref_by_nodeaddr(node_address, number);
 	if (segment_state != NULL) {
 		// make a copy of the current decoder addresses for logging purposes
-		t_bidib_segment_state_intern segment_state_intern_query = 
+		t_bidib_segment_state_intern segment_state_intern_query =
 				bidib_state_get_segment_state(segment_state);
 		if (segment_state->dcc_addresses->len > 0) {
 			g_array_remove_range(segment_state->dcc_addresses, 0,
@@ -642,7 +642,7 @@ void bidib_state_bm_address(t_bidib_node_address node_address, uint8_t number,
 		bidib_state_free_single_segment_state_intern(segment_state_intern_query);
 	} else if (!(address_count == 1 && addresses[0] == 0x00 && addresses[1] == 0x00)) {
 		// ignore free messages for unconnected segments (happens after track output is turned on)
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No segment with number 0x%02x configured for node address "
 		                "0x%02x 0x%02x 0x%02x 0x00",
 		                number, node_address.top, node_address.sub, node_address.subsub);
@@ -689,7 +689,7 @@ void bidib_state_bm_current(t_bidib_node_address node_address, uint8_t number,
 			segment_state->power_consumption.known = false;
 		}
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No segment with number 0x%02x configured for node address "
 		                "0x%02x 0x%02x 0x%02x 0x0",
 		                number, node_address.top, node_address.sub, node_address.subsub);
@@ -706,7 +706,7 @@ void bidib_state_bm_speed(t_bidib_dcc_address dcc_address, uint8_t speedl,
 	if (train_state != NULL) {
 		train_state->detected_kmh_speed = (speedh << 8) | speedl;
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No train configured for dcc address 0x%02x 0x%02x",
 		                dcc_address.addrl, dcc_address.addrh);
 	}
@@ -743,7 +743,7 @@ void bidib_state_bm_dyn_state(t_bidib_dcc_address dcc_address, uint8_t dyn_num,
 			train_state->decoder_state.container3_storage = value;
 		}
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No train configured for dcc address 0x%02x 0x%02x",
 		                dcc_address.addrl, dcc_address.addrh);
 	}
@@ -814,7 +814,7 @@ void bidib_state_boost_diagnostic(t_bidib_node_address node_address, uint8_t len
 			}
 		}
 	} else {
-		syslog_libbidib(LOG_ERR, 
+		syslog_libbidib(LOG_ERR,
 		                "No booster configured with node address "
 		                "0x%02x 0x%02x 0x%02x 0x0",
 		                node_address.top, node_address.sub, node_address.subsub);

--- a/test/unit/config_tests_config/bidib_track_config.yml
+++ b/test/unit/config_tests_config/bidib_track_config.yml
@@ -77,8 +77,10 @@ boards:
     segments:
       - id: seg1
         address: 0x00
+        length: 10.2cm
       - id: seg2
         address: 0x01
+        length: 20.5cm
 
   - id: board2
     peripherals:

--- a/test/unit/state_tests_config/bidib_track_config.yml
+++ b/test/unit/state_tests_config/bidib_track_config.yml
@@ -52,7 +52,10 @@ boards:
     segments:
       - id: seg1
         address: 0x00
+        length: 3.4cm
       - id: seg2
         address: 0x01
+        length: 40.3cm
       - id: seg3
         address: 0x02
+        length: 5.1cm


### PR DESCRIPTION
Closes #11 

CMakeLists.txt now provides an install target. This installs the dynamic and static library, as well as the include headers. These are installed according to the system defaults. On Linux, this is /usr/local/lib and /usr/local/include respectively. Furthermore, a pkg-config (.pc) is installed for each library version respectively. This makes the libraries easily includable from other CMakeLists.txt.

The above functionality was added in the first commit. The most changes in CMakeLists.txt in the second commit are simply formatting.

I have not been able to test this on a Mac. Not sure what the default paths are there, but should work nonetheless.