### PR TITLE
Preserve train direction

### DIFF
--- a/include/definitions/bidib_definitions_custom.h
+++ b/include/definitions/bidib_definitions_custom.h
@@ -283,6 +283,7 @@ typedef struct {
 	bool on_track;
 	t_bidib_train_orientation orientation;
 	int set_speed_step;
+	bool set_is_forwards;
 	t_bidib_cs_ack ack;
 	int detected_kmh_speed;
 	size_t peripheral_cnt;
@@ -427,6 +428,7 @@ typedef struct {
 typedef struct {
 	bool known_and_avail;
 	int speed_step;
+	bool is_forwards;
 } t_bidib_train_speed_step_query;
 
 typedef struct {

--- a/src/highlevel/bidib_highlevel_getter.c
+++ b/src/highlevel/bidib_highlevel_getter.c
@@ -129,6 +129,7 @@ static t_bidib_train_state *bidib_get_state_trains(void) {
 		state[i].data.on_track = tmp->on_track;
 		state[i].data.orientation = tmp->orientation;
 		state[i].data.set_speed_step = tmp->set_speed_step;
+		state[i].data.set_is_forwards = tmp->set_is_forwards;
 		state[i].data.ack = tmp->ack;
 		state[i].data.detected_kmh_speed = tmp->detected_kmh_speed;
 		state[i].data.peripheral_cnt = tmp->peripherals->len;
@@ -1012,6 +1013,7 @@ t_bidib_train_state_query bidib_get_train_state(const char *train) {
 		query.data.on_track = train_state->on_track;
 		query.data.orientation = train_state->orientation;
 		query.data.set_speed_step = train_state->set_speed_step;
+		query.data.set_is_forwards = train_state->set_is_forwards;
 		query.data.detected_kmh_speed = train_state->detected_kmh_speed;
 		query.data.ack = train_state->ack;
 		query.data.peripheral_cnt = train_state->peripherals->len;
@@ -1134,6 +1136,7 @@ t_bidib_train_speed_step_query bidib_get_train_speed_step(const char *train) {
 	if (train_state != NULL && train_state->on_track) {
 		query.known_and_avail = true;
 		query.speed_step = train_state->set_speed_step;
+		query.is_forwards = train_state->set_is_forwards;
 	}
 	pthread_mutex_unlock(&bidib_state_track_mutex);
 	return query;

--- a/src/highlevel/bidib_highlevel_getter.c
+++ b/src/highlevel/bidib_highlevel_getter.c
@@ -1127,7 +1127,7 @@ t_bidib_train_position_query bidib_get_train_position(const char *train) {
 }
 
 t_bidib_train_speed_step_query bidib_get_train_speed_step(const char *train) {
-	t_bidib_train_speed_step_query query = {false, 0};
+	t_bidib_train_speed_step_query query = {false, 0, true};
 	if (train == NULL) {
 		return query;
 	}

--- a/src/highlevel/bidib_highlevel_setter.c
+++ b/src/highlevel/bidib_highlevel_setter.c
@@ -319,6 +319,14 @@ int bidib_set_train_speed(const char *train, int speed, const char *track_output
 		syslog_libbidib(LOG_ERR, "Set train speed: board %s has no track output", track_output);
 		return 1;
 	} else {
+		const uint8_t speed_unsigned = (uint8_t) abs(speed);
+		bool is_forwards = (speed > 0);
+		if (speed == 0) {
+			// Preserve the orientation of the train headlights
+			t_bidib_train_state_intern *tmp_train_state = bidib_state_get_train_state_ref(train);
+			is_forwards = tmp_train_state->set_is_forwards;
+		}
+		
 		t_bidib_cs_drive_mod params;
 		params.dcc_address = tmp_train->dcc_addr;
 		switch (tmp_train->dcc_speed_steps) {
@@ -334,7 +342,7 @@ int bidib_set_train_speed(const char *train, int speed, const char *track_output
 				break;
 		}
 		params.active = 0x01;
-		params.speed = bidib_lib_speed_to_dcc_format(speed);
+		params.speed = bidib_lib_speed_to_dcc_format(speed_unsigned, is_forwards);
 		params.function1 = 0x00;
 		params.function2 = 0x00;
 		params.function3 = 0x00;

--- a/src/parser/bidib_config_parser_train.c
+++ b/src/parser/bidib_config_parser_train.c
@@ -381,6 +381,7 @@ static bool bidib_config_parse_single_train(yaml_parser_t *parser) {
 							train_state.on_track = false;
 							train_state.orientation = BIDIB_TRAIN_ORIENTATION_LEFT;
 							train_state.set_speed_step = 0;
+							train_state.set_is_forwards = true;
 							train_state.ack = BIDIB_DCC_ACK_PENDING;
 							train_state.detected_kmh_speed = 0;
 							train_state.peripherals = g_array_sized_new(

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -369,17 +369,9 @@ int bidib_dcc_speed_to_lib_format(uint8_t speed) {
 	}
 }
 
-uint8_t bidib_lib_speed_to_dcc_format(int speed) {
-	uint8_t bidib_speed = 0x00;
-	if (speed >= 0) {
-		bidib_speed = (uint8_t) (bidib_speed | (1 << 7));
-	} else {
-		speed = speed * -1;
-	}
-	bidib_speed = (uint8_t) (bidib_speed | speed);
-	if (speed != 0) {
-		bidib_speed++;
-	}
+uint8_t bidib_lib_speed_to_dcc_format(uint8_t speed, bool is_forwards) {
+	uint8_t bidib_speed = (uint8_t) (0x00 | (is_forwards << 7) | speed);
+	bidib_speed += (speed != 0);
 	return bidib_speed;
 }
 
@@ -717,6 +709,7 @@ void bidib_state_reset(void) {
 		train_state->on_track = false;
 		train_state->orientation = BIDIB_TRAIN_ORIENTATION_LEFT;
 		train_state->set_speed_step = 0;
+		train_state->set_is_forwards = true;
 		train_state->ack = BIDIB_DCC_ACK_PENDING;
 		for (size_t j = 0; j < train_state->peripherals->len; j++) {
 			g_array_index(train_state->peripherals,

--- a/src/state/bidib_state_intern.h
+++ b/src/state/bidib_state_intern.h
@@ -52,6 +52,7 @@ typedef struct {
 	bool on_track;
 	t_bidib_train_orientation orientation;
 	int set_speed_step;
+	bool set_is_forwards;
 	t_bidib_cs_ack ack;
 	unsigned int detected_kmh_speed;
 	GArray *peripherals;
@@ -207,9 +208,10 @@ int bidib_dcc_speed_to_lib_format(uint8_t speed);
  * Converts a lib speed to bidib format.
  *
  * @param speed the speed in lib format.
+ * @param is_forwards the direction of travel.
  * @return the speed in bidib format.
  */
-uint8_t bidib_lib_speed_to_dcc_format(int speed);
+uint8_t bidib_lib_speed_to_dcc_format(uint8_t speed, bool is_forwards);
 
 /**
  * Converts the void, freeze and nosignal booster confidence values to

--- a/src/state/bidib_state_setter.c
+++ b/src/state/bidib_state_setter.c
@@ -250,6 +250,7 @@ void bidib_state_cs_drive(t_bidib_cs_drive_mod params) {
 		                           params.function3, params.function4};
 		if (params.active == 0x00) {
 			train_state->set_speed_step = 0;
+			train_state->set_is_forwards = true;
 			for (size_t i = 0; i < train_state->peripherals->len; i++) {
 				peripheral_state = &g_array_index(train_state->peripherals,
 				                                  t_bidib_train_peripheral_state, i);
@@ -259,6 +260,7 @@ void bidib_state_cs_drive(t_bidib_cs_drive_mod params) {
 			if (params.active & (1 << 0)) {
 				// speed active
 				train_state->set_speed_step = bidib_dcc_speed_to_lib_format(params.speed);
+				train_state->set_is_forwards = (params.speed >= 0x80);
 			}
 			train_state->ack = BIDIB_DCC_ACK_PENDING;
 			if (params.active & (1 << 1)) {

--- a/test/unit/bidib_state_tests.c
+++ b/test/unit/bidib_state_tests.c
@@ -339,7 +339,7 @@ static void cs_drive_and_ack_update_state_correctly(void **state __attribute__((
 	query = bidib_get_train_state("train1");
 	assert_int_equal(query.known, true);
 	assert_int_equal(query.data.on_track, true);
-	assert_int_equal(query.data.set_speed_step, 8);
+	assert_int_equal(query.data.set_speed_step, -8);
 	assert_int_equal(query.data.set_is_forwards, false);
 	assert_int_equal(query.data.orientation, BIDIB_TRAIN_ORIENTATION_LEFT);
 	assert_int_equal(query.data.ack, BIDIB_DCC_ACK_OUTPUT);

--- a/test/unit/bidib_state_tests.c
+++ b/test/unit/bidib_state_tests.c
@@ -330,8 +330,9 @@ static void cs_drive_and_ack_update_state_correctly(void **state __attribute__((
 	assert_int_equal(query.known, true);
 	assert_int_equal(query.data.on_track, true);
 	assert_int_equal(query.data.set_speed_step, 0);
+	assert_int_equal(query.data.set_is_forwards, true);
 	assert_int_equal(query.data.ack, BIDIB_DCC_ACK_PENDING);
-	bidib_set_train_speed("train1", 8, "board1");
+	bidib_set_train_speed("train1", -8, "board1");
 	wait_for_cs_drive_change = false;
 	usleep(100000);
 	bidib_free_train_state_query(query);
@@ -339,6 +340,7 @@ static void cs_drive_and_ack_update_state_correctly(void **state __attribute__((
 	assert_int_equal(query.known, true);
 	assert_int_equal(query.data.on_track, true);
 	assert_int_equal(query.data.set_speed_step, 8);
+	assert_int_equal(query.data.set_is_forwards, false);
 	assert_int_equal(query.data.orientation, BIDIB_TRAIN_ORIENTATION_LEFT);
 	assert_int_equal(query.data.ack, BIDIB_DCC_ACK_OUTPUT);
 	bidib_free_train_state_query(query);


### PR DESCRIPTION
When train speed is set to zero, the reverse bit of the dcc params now preserves the direction of the train. Trains no longer swap their headlights when they stop after driving backwards.