### PR TITLE
Merge pthread locking changes and fixes

### DIFF
--- a/include/lowlevel/bidib_lowlevel_feature.h
+++ b/include/lowlevel/bidib_lowlevel_feature.h
@@ -65,11 +65,11 @@ void bidib_send_feature_get(t_bidib_node_address node_address, uint8_t feature_n
                             unsigned int action_id);
 
 /**
- * Queries a single feature value of a node.
+ * Sets a single feature value of a node.
  *
  * @param node_address the three bytes on top of the address stack.
  * @param feature_number the number of the feature.
- * @param feature_value the value for the future.
+ * @param feature_value the value for the feature.
  * @param action_id reference number to a high level function call, 0 to signal
  * no reference.
  */

--- a/src/highlevel/bidib_highlevel_getter.c
+++ b/src/highlevel/bidib_highlevel_getter.c
@@ -1241,7 +1241,7 @@ t_bidib_train_position_query bidib_get_train_position_intern(const char *train) 
 
 t_bidib_train_position_query bidib_get_train_position(const char *train) {
 	pthread_rwlock_rdlock(&bidib_state_trains_rwlock);
-	pthread_rwlock_wrlock(&bidib_state_track_rwlock);
+	pthread_rwlock_rdlock(&bidib_state_track_rwlock);
 	t_bidib_train_position_query query = bidib_get_train_position_intern(train);
 	pthread_rwlock_unlock(&bidib_state_track_rwlock);
 	pthread_rwlock_unlock(&bidib_state_trains_rwlock);

--- a/src/highlevel/bidib_highlevel_setter.c
+++ b/src/highlevel/bidib_highlevel_setter.c
@@ -253,7 +253,7 @@ int bidib_set_signal(const char *signal, const char *aspect) {
 						aspect_port_value = &g_array_index(aspect_mapping->port_values, 
 						                                   t_bidib_dcc_aspect_port_value, k);
 						params.data = (uint8_t) (aspect_port_value->port & 0x1F);
-						params.data = (uint8_t) (aspect_port_value->value | (1 << 5));
+						params.data = params.data | (uint8_t) (aspect_port_value->value | (1 << 5));
 						params.data = params.data | (dcc_mapping->extended_accessory << 7);
 						bidib_send_cs_accessory_intern(tmp_addr, params, action_id);
 					}
@@ -318,9 +318,9 @@ int bidib_set_peripheral(const char *peripheral, const char *aspect) {
 					                peripheral, board_i->id->str, board_i->node_addr.top,
 					                board_i->node_addr.sub, board_i->node_addr.subsub,
 					                aspect_mapping->id->str, aspect_mapping->value, action_id);
-					pthread_rwlock_unlock(&bidib_state_boards_rwlock);
 					bidib_send_lc_output(board_i->node_addr, peripheral_mapping->port.port0,
 					                     peripheral_mapping->port.port1, aspect_mapping->value, action_id);
+					pthread_rwlock_unlock(&bidib_state_boards_rwlock);
 					return 0;
 				} else {
 					pthread_rwlock_unlock(&bidib_state_boards_rwlock);

--- a/src/lowlevel/bidib_lowlevel_track.c
+++ b/src/lowlevel/bidib_lowlevel_track.c
@@ -115,8 +115,8 @@ void bidib_send_cs_accessory(t_bidib_node_address node_address,
 	pthread_rwlock_wrlock(&bidib_state_track_rwlock);
 	pthread_rwlock_rdlock(&bidib_state_boards_rwlock);
 	bidib_send_cs_accessory_intern(node_address, cs_accessory_params, action_id);
-	pthread_rwlock_unlock(&bidib_state_track_rwlock);
 	pthread_rwlock_unlock(&bidib_state_boards_rwlock);
+	pthread_rwlock_unlock(&bidib_state_track_rwlock);
 }
 
 void bidib_send_cs_pom(t_bidib_node_address node_address,

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -245,8 +245,12 @@ void bidib_state_query_occupancy(void) {
 }
 
 void bidib_state_set_board_features(void) {
-	// Acquire bidib_state_boards_rwlock write lock because we need to wait for board features to change.
-	pthread_rwlock_wrlock(&bidib_state_boards_rwlock);
+	// Setting is done not internally but sends a bidib command to a board.
+	// The board will eventually send an answer to this, upon which the bidib
+	// state of this board is adjusted -> but that happens when the answer is
+	// received, not in here -> thus read lock is enough. Also, the change would
+	// happen in the "trackstate", not in the boards.
+	pthread_rwlock_rdlock(&bidib_state_boards_rwlock);
 	for (size_t i = 0; i < bidib_boards->len; i++) {
 		const t_bidib_board *const board_i = &g_array_index(bidib_boards, t_bidib_board, i);
 		if (board_i->connected) {

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -245,11 +245,6 @@ void bidib_state_query_occupancy(void) {
 }
 
 void bidib_state_set_board_features(void) {
-	// Setting is done not internally but sends a bidib command to a board.
-	// The board will eventually send an answer to this, upon which the bidib
-	// state of this board is adjusted -> but that happens when the answer is
-	// received, not in here -> thus read lock is enough. Also, the change would
-	// happen in the "trackstate", not in the boards.
 	pthread_rwlock_rdlock(&bidib_state_boards_rwlock);
 	for (size_t i = 0; i < bidib_boards->len; i++) {
 		const t_bidib_board *const board_i = &g_array_index(bidib_boards, t_bidib_board, i);


### PR DESCRIPTION
Closes #21 
Added the fixes to incorrect lock release order and minor fixes in assigning a parameter when setting signal values.   
Changes were tested as part of the stop-delay-benchmarking branch.