### PR TITLE
add reset for detected train speed

### DIFF
--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -770,6 +770,7 @@ void bidib_state_reset(void) {
 		train_state->on_track = false;
 		train_state->orientation = BIDIB_TRAIN_ORIENTATION_LEFT;
 		train_state->set_speed_step = 0;
+		train_state->detected_kmh_speed = 0;
 		train_state->set_is_forwards = true;
 		train_state->ack = BIDIB_DCC_ACK_PENDING;
 		for (size_t j = 0; j < train_state->peripherals->len; j++) {


### PR DESCRIPTION
Closes #36 

Adds a simple reset for the "detected speed" entry for train state.