### PR TITLE
merge startup overload fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install cmocka
-      run: sudo apt-get install -y --no-install-recommends libyaml-dev libcmocka-dev
+    - name: Install cmocka yaml and glib
+      run: sudo apt update; sudo apt install -y --no-install-recommends libyaml-dev libcmocka-dev libglib2.0-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/include/lowlevel/bidib_lowlevel_system.h
+++ b/include/lowlevel/bidib_lowlevel_system.h
@@ -124,6 +124,7 @@ void bidib_send_sys_get_error(t_bidib_node_address node_address, unsigned int ac
 /**
  * Resets the bidib system, including all buffered messages. NOT threadsafe!
  * Ensure that no other libbidib functions are called during execution.
+ * This will also set initial values for all accessories and peripherals.
  * 
  * @param action_id reference number to a high level function call, 0 to signal
  * no reference.

--- a/src/lowlevel/bidib_lowlevel_system.c
+++ b/src/lowlevel/bidib_lowlevel_system.c
@@ -108,7 +108,7 @@ void bidib_send_sys_reset(unsigned int action_id) {
 	uint8_t addr_stack[] = {0x00, 0x00, 0x00, 0x00};
 	bidib_buffer_message_without_data(addr_stack, MSG_SYS_RESET, action_id);
 	bidib_flush();
-	usleep(1500000); // wait for node login
+	usleep(1500000); // wait for node login, 1.5s
 	bidib_node_state_table_reset(true);
 	bidib_uplink_queue_reset(true);
 	bidib_uplink_error_queue_reset(true);
@@ -122,12 +122,12 @@ void bidib_send_sys_reset(unsigned int action_id) {
 	bidib_state_reset_train_params();
 	bidib_set_track_output_state_all(BIDIB_CS_GO);
 	bidib_flush();
-	usleep(500000); // wait for track output so it can receive initial values
+	usleep(500000); // wait for track output so it can receive initial values, 0.5s
 	pthread_rwlock_rdlock(&bidib_boards_rwlock);
 	bidib_state_query_occupancy();
 	pthread_rwlock_unlock(&bidib_boards_rwlock);
 	bidib_flush();
-	usleep(500000); // wait for occupancy data
+	usleep(500000); // wait for occupancy data, 0.5s
 	bidib_state_set_initial_values();
 }
 

--- a/src/lowlevel/bidib_lowlevel_system.c
+++ b/src/lowlevel/bidib_lowlevel_system.c
@@ -108,7 +108,7 @@ void bidib_send_sys_reset(unsigned int action_id) {
 	uint8_t addr_stack[] = {0x00, 0x00, 0x00, 0x00};
 	bidib_buffer_message_without_data(addr_stack, MSG_SYS_RESET, action_id);
 	bidib_flush();
-	usleep(1500000); // wait for node login, 1.5s
+	usleep(1000000); // wait for node login, 1.0s
 	bidib_node_state_table_reset(true);
 	bidib_uplink_queue_reset(true);
 	bidib_uplink_error_queue_reset(true);

--- a/src/lowlevel/bidib_lowlevel_system.c
+++ b/src/lowlevel/bidib_lowlevel_system.c
@@ -108,7 +108,7 @@ void bidib_send_sys_reset(unsigned int action_id) {
 	uint8_t addr_stack[] = {0x00, 0x00, 0x00, 0x00};
 	bidib_buffer_message_without_data(addr_stack, MSG_SYS_RESET, action_id);
 	bidib_flush();
-	usleep(1000000); // wait for node login, 1.0s
+	usleep(1500000); // wait for node login, 1.5s
 	bidib_node_state_table_reset(true);
 	bidib_uplink_queue_reset(true);
 	bidib_uplink_error_queue_reset(true);

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -324,10 +324,11 @@ void bidib_state_set_initial_values(void) {
 		initial_value = 
 				&g_array_index(bidib_initial_values.signals, t_bidib_state_initial_value, i);
 		bidib_set_signal(initial_value->id->str, initial_value->value->str);
-		// Heuristic: Flush after every 8th signal and wait a little, so as not to overload the boards
-		if (i % 8 == 0) {
+		// Heuristic: Flush after every 6th signal and wait a little, so as not to overload the boards
+		// less often than for points because set-signal causes only one response, not two
+		if (i % 6 == 0) {
 			bidib_flush();
-			usleep(25000); // wait for 0.025s, less than for points because there's just more signals
+			usleep(25000); // wait for 0.025s
 		}
 	}
 	bidib_flush();

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -110,7 +110,7 @@ static bool bidib_state_query_nodetab(t_bidib_node_address node_address,
 	if (first_node) {
 		uint8_t addr_stack[] = {node_address.top, node_address.sub, node_address.subsub, 0x00};
 		bidib_node_state_get_and_incr_send_seqnum(addr_stack);
-		bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
+		//bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
 	}
 	
 	uint8_t node_count = 0;

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -103,7 +103,15 @@ int bidib_state_init(const char *config_dir) {
 //   - True: Node table changed during processing (nodes were lost or detected). 
 //           Processing has to be restarted again.
 static bool bidib_state_query_nodetab(t_bidib_node_address node_address,
-                                      GQueue *sub_iface_queue) {
+                                      GQueue *sub_iface_queue, bool first_node) {
+	// Hacky: the master/main node (0x00 0x00 0x00) needs to have the sequence numbers incremented
+	// because the previous MSG_SYS_RESET is seq 1 and apparently this is not 
+	// set to its default by that RESET.
+	if (first_node) {
+		uint8_t addr_stack[] = {node_address.top, node_address.sub, node_address.subsub, 0x00};
+		bidib_node_state_get_and_incr_send_seqnum(addr_stack);
+		//bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
+	}
 	uint8_t node_count = 0;
 	// Request to entire node table and read the incoming messages until
 	// a message of type MSG_NODETAB_COUNT is received, which contains
@@ -206,10 +214,10 @@ void bidib_state_init_allocation_table(void) {
 	GQueue *sub_iface_queue = g_queue_new();
 	t_bidib_node_address *sub_interface;
 	while (true) {
-		bool reset = bidib_state_query_nodetab(interface, sub_iface_queue);
+		bool reset = bidib_state_query_nodetab(interface, sub_iface_queue, true);
 		while (!reset && !g_queue_is_empty(sub_iface_queue)) {
 			sub_interface = g_queue_pop_head(sub_iface_queue);
-			reset = bidib_state_query_nodetab(*sub_interface, sub_iface_queue);
+			reset = bidib_state_query_nodetab(*sub_interface, sub_iface_queue, false);
 			free(sub_interface);
 			sub_interface = NULL;
 		}

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -107,11 +107,11 @@ static bool bidib_state_query_nodetab(t_bidib_node_address node_address,
 	// Hacky: the master/main node (0x00 0x00 0x00) needs to have the sequence numbers incremented
 	// because the previous MSG_SYS_RESET is seq 1 and apparently this is not 
 	// set to its default by that RESET.
-	if (first_node) {
-		uint8_t addr_stack[] = {node_address.top, node_address.sub, node_address.subsub, 0x00};
-		bidib_node_state_get_and_incr_send_seqnum(addr_stack);
-		//bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
-	}
+	//if (first_node) {
+	//	uint8_t addr_stack[] = {node_address.top, node_address.sub, node_address.subsub, 0x00};
+	//	bidib_node_state_get_and_incr_send_seqnum(addr_stack);
+	//	//bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
+	//}
 	
 	uint8_t node_count = 0;
 	// Request to entire node table and read the incoming messages until

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -103,15 +103,15 @@ int bidib_state_init(const char *config_dir) {
 //   - True: Node table changed during processing (nodes were lost or detected). 
 //           Processing has to be restarted again.
 static bool bidib_state_query_nodetab(t_bidib_node_address node_address,
-                                      GQueue *sub_iface_queue, bool first_node) {
-	// Hacky: the master/main node (0x00 0x00 0x00) needs to have the sequence numbers incremented
-	// because the previous MSG_SYS_RESET is seq 1 and apparently this is not 
-	// set to its default by that RESET.
-	if (first_node) {
+                                      GQueue *sub_iface_queue, bool node_seq_incr) {
+	// The master/main node needs to have the send sequence number incremented
+	// because the previous MSG_SYS_RESET uses seq 1, so now it expects 2, and because of the reset
+	// we perform on the libbidib side, we think the node expects send sequence number 1.
+	if (node_seq_incr) {
 		uint8_t addr_stack[] = {node_address.top, node_address.sub, node_address.subsub, 0x00};
 		bidib_node_state_get_and_incr_send_seqnum(addr_stack);
-		//bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
 	}
+	
 	uint8_t node_count = 0;
 	// Request to entire node table and read the incoming messages until
 	// a message of type MSG_NODETAB_COUNT is received, which contains

--- a/src/state/bidib_state.c
+++ b/src/state/bidib_state.c
@@ -103,16 +103,7 @@ int bidib_state_init(const char *config_dir) {
 //   - True: Node table changed during processing (nodes were lost or detected). 
 //           Processing has to be restarted again.
 static bool bidib_state_query_nodetab(t_bidib_node_address node_address,
-                                      GQueue *sub_iface_queue, bool first_node) {
-	// Hacky: the master/main node (0x00 0x00 0x00) needs to have the sequence numbers incremented
-	// because the previous MSG_SYS_RESET is seq 1 and apparently this is not 
-	// set to its default by that RESET.
-	//if (first_node) {
-	//	uint8_t addr_stack[] = {node_address.top, node_address.sub, node_address.subsub, 0x00};
-	//	bidib_node_state_get_and_incr_send_seqnum(addr_stack);
-	//	//bidib_node_state_get_and_incr_receive_seqnum(addr_stack);
-	//}
-	
+                                      GQueue *sub_iface_queue) {
 	uint8_t node_count = 0;
 	// Request to entire node table and read the incoming messages until
 	// a message of type MSG_NODETAB_COUNT is received, which contains
@@ -215,10 +206,10 @@ void bidib_state_init_allocation_table(void) {
 	GQueue *sub_iface_queue = g_queue_new();
 	t_bidib_node_address *sub_interface;
 	while (true) {
-		bool reset = bidib_state_query_nodetab(interface, sub_iface_queue, true);
+		bool reset = bidib_state_query_nodetab(interface, sub_iface_queue);
 		while (!reset && !g_queue_is_empty(sub_iface_queue)) {
 			sub_interface = g_queue_pop_head(sub_iface_queue);
-			reset = bidib_state_query_nodetab(*sub_interface, sub_iface_queue, false);
+			reset = bidib_state_query_nodetab(*sub_interface, sub_iface_queue);
 			free(sub_interface);
 			sub_interface = NULL;
 		}

--- a/src/transmission/bidib_transmission_intern.h
+++ b/src/transmission/bidib_transmission_intern.h
@@ -59,7 +59,7 @@ typedef struct {
 	uint8_t receive_seqnum;
 	uint8_t send_seqnum;
 	bool stall;
-	int current_max_respond;
+	int current_response_bytes;
 	// if this node is stalled, this queue contains all (sub)nodes that are
 	// stalled because of it
 	GQueue *stall_affected_nodes_queue; 

--- a/src/transmission/bidib_transmission_node_states.c
+++ b/src/transmission/bidib_transmission_node_states.c
@@ -258,7 +258,7 @@ unsigned int bidib_node_state_update(const uint8_t *const addr_stack, uint8_t re
 		}
 		syslog_libbidib(LOG_DEBUG, 
 		                "Expecting responses with a total of %d bytes from 0x%02x 0x%02x 0x%02x 0x%02x"
-						" after processing received message of type %s with action id: %d",
+						" after receiving message of type %s with action id: %d",
 		                state->current_response_bytes, addr_stack[0], addr_stack[1], addr_stack[2], 
 		                addr_stack[3], bidib_message_string_mapping[response_type], action_id);
 	}

--- a/src/transmission/bidib_transmission_node_states.c
+++ b/src/transmission/bidib_transmission_node_states.c
@@ -198,7 +198,7 @@ static int bidib_node_try_queued_messages(t_bidib_node_state *state) {
 			free(queued_msg);
 			sent_count++;
 		} else {
-			syslog_libbidib(LOG_WARNING, 
+			syslog_libbidib(LOG_DEBUG, 
 			                "Unable to dequeue msg, response queue full. Msg info: "
 			                "type: %s to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d. "
 			                "Current response bytes: %d; size of response to add: %d",

--- a/src/transmission/bidib_transmission_node_states.c
+++ b/src/transmission/bidib_transmission_node_states.c
@@ -199,9 +199,9 @@ static int bidib_node_try_queued_messages(t_bidib_node_state *state) {
 			sent_count++;
 		} else {
 			syslog_libbidib(LOG_WARNING, 
-			                "Unable to send queued msg, not enough space in response queue. Msg info: "
-			                "type: %s addressed to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d. "
-			                "Current_response_bytes: %d; response size to be added: %d",
+			                "Unable to dequeue msg, response queue full. Msg info: "
+			                "type: %s to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d. "
+			                "Current response bytes: %d; size of response to add: %d",
 			                bidib_message_string_mapping[queued_msg->type], 
 			                state->addr[0], state->addr[1], state->addr[2], state->addr[3], 
 			                queued_msg->action_id, state->current_response_bytes, 

--- a/src/transmission/bidib_transmission_node_states.c
+++ b/src/transmission/bidib_transmission_node_states.c
@@ -42,6 +42,8 @@
 pthread_mutex_t bidib_node_state_table_mutex;
 
 static GHashTable *node_state_table = NULL;
+// Limit for the number of bytes expected in form of responses from a node.
+// (to avoid node overload)
 static int response_limit = 48;
 
 void bidib_node_state_table_init() {
@@ -51,7 +53,7 @@ void bidib_node_state_table_init() {
 static void bidib_node_state_add_response(uint8_t type, t_bidib_node_state *state,
                                           int message_max_resp, unsigned int action_id) {
 	if (message_max_resp > 0) {
-		state->current_max_respond += message_max_resp;
+		state->current_response_bytes += message_max_resp;
 		t_bidib_response_queue_entry *response = malloc(sizeof(t_bidib_response_queue_entry));
 		response->type = type;
 		response->creation_time = time(NULL);
@@ -71,8 +73,9 @@ static void bidib_node_state_add_message(const uint8_t *const addr_stack, uint8_
 	message_entry->action_id = action_id;
 	g_queue_push_tail(state->message_queue, message_entry);
 	syslog_libbidib(LOG_DEBUG, 
-	                "Enqueued type: 0x%02x to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d",
-	                type, addr_stack[0], addr_stack[1], addr_stack[2], addr_stack[3], action_id);
+	                "Enqueued msg with type: %s to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d",
+	                bidib_message_string_mapping[type], addr_stack[0], addr_stack[1], addr_stack[2], 
+	                addr_stack[3], action_id);
 }
 
 // May write to member in node_state_table.
@@ -85,7 +88,7 @@ static t_bidib_node_state *bidib_node_query(const uint8_t *const addr_stack) {
 		state->receive_seqnum = 0x01;
 		state->send_seqnum = 0x01;
 		state->stall = false;
-		state->current_max_respond = 0;
+		state->current_response_bytes = 0;
 		state->stall_affected_nodes_queue = g_queue_new();
 		state->response_queue = g_queue_new();
 		state->message_queue = g_queue_new();
@@ -152,18 +155,19 @@ bool bidib_node_try_send(const uint8_t *const addr_stack, uint8_t type,
 	int max_response = bidib_response_info[type][1];
 	bool status;
 	if (bidib_node_stall_ready(addr_stack) && g_queue_is_empty(state->message_queue) &&
-	    state->current_max_respond + max_response <= response_limit) {
+	    state->current_response_bytes + max_response <= response_limit) {
 		// Node is ready
 		bidib_node_state_add_response(type, state, max_response, action_id);
 		status = true;
+		syslog_libbidib(LOG_DEBUG, 
+		                "Expecting responses with a total of %d bytes from 0x%02x 0x%02x 0x%02x 0x%02x",
+		                state->current_response_bytes, addr_stack[0], addr_stack[1], addr_stack[2], 
+		                addr_stack[3]);
 	} else {
 		// Node is not ready
 		bidib_node_state_add_message(addr_stack, type, message, state, action_id);
 		status = false;
 	}
-	syslog_libbidib(LOG_DEBUG, "Used output buffer for 0x%02x 0x%02x 0x%02x 0x%02x is %d bytes",
-	                addr_stack[0], addr_stack[1], addr_stack[2], addr_stack[3],
-	                state->current_max_respond);
 	pthread_mutex_unlock(&bidib_node_state_table_mutex);
 	return status;
 }
@@ -177,16 +181,16 @@ static void bidib_node_try_queued_messages(t_bidib_node_state *state) {
 	while (bidib_node_stall_ready((uint8_t *) state->addr) &&
 	       !g_queue_is_empty(state->message_queue)) {
 		t_bidib_message_queue_entry *queued_msg = g_queue_peek_head(state->message_queue);
-		if (state->current_max_respond + bidib_response_info[queued_msg->type][1] <= response_limit) {
+		if (state->current_response_bytes + bidib_response_info[queued_msg->type][1] <= response_limit) {
 			// capacity sufficient -> send messages
 			bidib_node_state_add_response(queued_msg->type, state,
 			                              bidib_response_info[queued_msg->type][1],
 			                              queued_msg->action_id);
 			bidib_add_to_buffer(queued_msg->message);
 			syslog_libbidib(LOG_DEBUG, 
-			                "Dequeued type: 0x%02x to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d",
-			                queued_msg->type, state->addr[0], state->addr[1], state->addr[2],
-			                state->addr[3], queued_msg->action_id);
+			                "Dequeued msg with type: %s to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d",
+			                bidib_message_string_mapping[queued_msg->type], state->addr[0], 
+			                state->addr[1], state->addr[2], state->addr[3], queued_msg->action_id);
 			g_queue_pop_head(state->message_queue);
 			free(queued_msg->message);
 			free(queued_msg);
@@ -194,11 +198,12 @@ static void bidib_node_try_queued_messages(t_bidib_node_state *state) {
 		} else {
 			syslog_libbidib(LOG_WARNING, 
 			                "bidib_node_try_queued_messages - Unable to send queued msg, "
-			                "not enough space in response queue. Message info: "
-			                "type: 0x%02x addressed to: 0x%02x 0x%02x 0x%02x 0x%02x"
-			                ". Current_max_respond: %d; response size to be added: %d",
-			                queued_msg->type, state->addr[0], state->addr[1], state->addr[2], 
-			                state->addr[3], state->current_max_respond, 
+			                "not enough space in response queue. Msg info: "
+			                "type: %s addressed to: 0x%02x 0x%02x 0x%02x 0x%02x action id: %d. "
+			                "Current_response_bytes: %d; response size to be added: %d",
+			                bidib_message_string_mapping[queued_msg->type], 
+			                state->addr[0], state->addr[1], state->addr[2], state->addr[3], 
+			                queued_msg->action_id, state->current_response_bytes, 
 			                bidib_response_info[queued_msg->type][1]);
 			break;
 		}
@@ -221,7 +226,7 @@ unsigned int bidib_node_state_update(const uint8_t *const addr_stack, uint8_t re
 			if (bidib_response_info[response->type][i] == response_type) {
 				// awaited answer matches message -> extend free capacity
 				g_queue_pop_head(state->response_queue);
-				state->current_max_respond -= bidib_response_info[response->type][1];
+				state->current_response_bytes -= bidib_response_info[response->type][1];
 				action_id = response->action_id;
 				free(response);
 				response = NULL;
@@ -231,12 +236,12 @@ unsigned int bidib_node_state_update(const uint8_t *const addr_stack, uint8_t re
 			           RESPONSE_QUEUE_EXPIRATION_SECS) {
 				// remove response queue entries older than x seconds
 				syslog_libbidib(LOG_ERR,
-				                "Response from: 0x%02x 0x%02x 0x%02x 0x%02x to type: 0x%02x "
+				                "Response from: 0x%02x 0x%02x 0x%02x 0x%02x to type: %s "
 				                "with action id: %d expected but not received",
 				                addr_stack[0], addr_stack[1], addr_stack[2], addr_stack[3],
-				                response->type, response->action_id);
+				                bidib_message_string_mapping[response->type], response->action_id);
 				g_queue_pop_head(state->response_queue);
-				state->current_max_respond -= bidib_response_info[response->type][1];
+				state->current_response_bytes -= bidib_response_info[response->type][1];
 				free(response);
 				response = NULL;
 				if (!g_queue_is_empty(state->response_queue)) {
@@ -246,9 +251,10 @@ unsigned int bidib_node_state_update(const uint8_t *const addr_stack, uint8_t re
 				}
 			}
 		}
-		syslog_libbidib(LOG_DEBUG, "Used output buffer for 0x%02x 0x%02x 0x%02x 0x%02x is %d bytes",
-		                addr_stack[0], addr_stack[1], addr_stack[2], addr_stack[3],
-		                state->current_max_respond);
+		syslog_libbidib(LOG_DEBUG, 
+		                "Expecting responses with a total of %d bytes from 0x%02x 0x%02x 0x%02x 0x%02x",
+		                state->current_response_bytes, addr_stack[0], addr_stack[1], addr_stack[2], 
+		                addr_stack[3]);
 	}
 	pthread_mutex_unlock(&bidib_node_state_table_mutex);
 	return action_id;

--- a/src/transmission/bidib_transmission_receive.c
+++ b/src/transmission/bidib_transmission_receive.c
@@ -215,7 +215,7 @@ static void bidib_log_received_message(const uint8_t *const addr_stack, uint8_t 
 	const int size = (message[0] + 1) * 5;
 	char hex_string[size];
 	bidib_build_message_hex_string(message, hex_string);
-	syslog_libbidib(LOG_DEBUG, "Message bytes: %s", hex_string);
+	syslog_libbidib(LOG_DEBUG, "Message bytes received: %s", hex_string);
 }
 
 // Shall only be called with bidib_boards_rwlock >= read acquired. 
@@ -234,7 +234,7 @@ static void bidib_log_sys_error(const uint8_t *const message,
 		switch (error_type) {
 			case (BIDIB_ERR_SEQUENCE):
 				g_string_printf(fault_name, "Expected MSG_NUM %d not %d", 
-				                message[data_index + 1], message[2]);
+				                message[data_index + 1], message[data_index + 2]);
 				break;
 			case (BIDIB_ERR_BUS):
 				g_string_printf(fault_name, "%s", 

--- a/src/transmission/bidib_transmission_receive.c
+++ b/src/transmission/bidib_transmission_receive.c
@@ -218,6 +218,14 @@ static void bidib_log_received_message(const uint8_t *const addr_stack, uint8_t 
 	syslog_libbidib(LOG_DEBUG, "Message bytes received: %s", hex_string);
 }
 
+static void bidib_log_received_message_no_msgbytes(const uint8_t *const addr_stack, uint8_t msg_seqnum,
+                                                   uint8_t type, int log_level, unsigned int action_id) {
+	syslog_libbidib(log_level, "Received from: 0x%02x 0x%02x 0x%02x 0x%02x seq: %d type: %s "
+	                "(0x%02x) action id: %d (msg bytes omitted)",
+	                addr_stack[0], addr_stack[1], addr_stack[2], addr_stack[3], msg_seqnum,
+	                bidib_message_string_mapping[type], type, action_id);
+}
+
 // Shall only be called with bidib_boards_rwlock >= read acquired. 
 static void bidib_log_sys_error(const uint8_t *const message, 
                                 t_bidib_node_address node_address, 
@@ -280,11 +288,11 @@ static void bidib_log_boost_stat_okay(const uint8_t *const message,
                                       unsigned int action_id) {
 	const t_bidib_board *const board = bidib_state_get_board_ref_by_nodeaddr(node_address);
 	int data_index = bidib_first_data_byte_index(message);
-	unsigned int msg_type = message[data_index];
+	unsigned int msg_boost_state_type = message[data_index];
 	
 	GString *msg_name = g_string_new("");
-	if (msg_type <= 0x84) {
-		g_string_printf(msg_name, "%s", bidib_boost_state_string_mapping[msg_type]);
+	if (msg_boost_state_type <= 0x84) {
+		g_string_printf(msg_name, "%s", bidib_boost_state_string_mapping[msg_boost_state_type]);
 	} else {
 		g_string_printf(msg_name, "UNKNOWN");
 	}
@@ -351,7 +359,7 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			free(message);
 			break;
 		case MSG_STALL:
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_WARNING,
+			bidib_log_received_message(addr_stack, seqnum, type, LOG_INFO,
 			                           message, action_id);
 			bidib_node_update_stall(addr_stack, message[message[0]]);
 			free(message);
@@ -422,8 +430,10 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_LC_STAT:
 			// update state
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
-			                           message, action_id);
+			// different logging than other messages because at least for the SWTbahn,
+			// reduce log spamming due to the sync2, sync3, sync4 peripherals
+			// constantly updating their aspect for the SWTbahn
+			bidib_log_received_message_no_msgbytes(addr_stack, seqnum, type, LOG_DEBUG, action_id);
 			peripheral_port.port0 = message[data_index];
 			peripheral_port.port1 = message[data_index + 1];
 			bidib_state_lc_stat(node_address, peripheral_port, message[data_index + 2], action_id);
@@ -455,7 +465,6 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_BM_FREE:
 			// update state
-			///TODO: keep at debug level or move back to info?
 			bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
 			                           message, action_id);
 			bidib_state_bm_occ(node_address, message[data_index], false);
@@ -488,8 +497,8 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_BM_CONFIDENCE:
 			// update state
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
-			                           message, action_id);
+			// msg bytes not interesting, omit
+			bidib_log_received_message_no_msgbytes(addr_stack, seqnum, type, LOG_DEBUG, action_id);
 			bidib_state_bm_confidence(node_address, message[data_index],
 			                          message[data_index + 1], message[data_index + 2],
 			                          action_id);
@@ -497,8 +506,8 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_BM_ADDRESS:
 			// update state
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
-			                           message, action_id);
+			// msg bytes not interesting, omit
+			bidib_log_received_message_no_msgbytes(addr_stack, seqnum, type, LOG_DEBUG, action_id);
 			bidib_state_bm_address(node_address, message[data_index],
 			                       (uint8_t) ((message[0] - data_index) / 2),
 			                       &message[data_index + 1]);
@@ -534,8 +543,8 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_BOOST_DIAGNOSTIC:
 			// update state
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
-			                           message, action_id);
+			// msg bytes not interesting (everything logged in state_boost_diag...), omit
+			bidib_log_received_message_no_msgbytes(addr_stack, seqnum, type, LOG_DEBUG, action_id);
 			bidib_state_boost_diagnostic(node_address,
 			                             (uint8_t) (message[0] - data_index + 1),
 			                             &message[data_index], action_id);
@@ -543,8 +552,8 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_ACCESSORY_STATE:
 			// update state and check if error
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
-			                           message, action_id);
+			// msg bytes are not very interesting here, omit
+			bidib_log_received_message_no_msgbytes(addr_stack, seqnum, type, LOG_DEBUG, action_id);
 			bidib_state_accessory_state(node_address, message[data_index],
 			                            message[data_index + 1], message[data_index + 2],
 			                            message[data_index + 3], message[data_index + 4],
@@ -587,8 +596,8 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 				pthread_rwlock_unlock(&bidib_boards_rwlock);
 				bidib_uplink_error_queue_add(message, type, addr_stack);
 			} else {
-				bidib_log_received_message(addr_stack, seqnum, type, LOG_DEBUG,
-				                           message, action_id);
+				// msg bytes not interesting (info printed in log_boost_stat_okay), omit
+				bidib_log_received_message_no_msgbytes(addr_stack, seqnum, type, LOG_DEBUG, action_id);
 				pthread_rwlock_rdlock(&bidib_boards_rwlock);
 				bidib_log_boost_stat_okay(message, node_address, action_id);
 				pthread_rwlock_unlock(&bidib_boards_rwlock);

--- a/src/transmission/bidib_transmission_receive.c
+++ b/src/transmission/bidib_transmission_receive.c
@@ -261,7 +261,7 @@ static void bidib_log_sys_error(const uint8_t *const message,
 		err_name = "UNKNOWN";
 		g_string_printf(fault_name, "UNKNOWN");
 	}
-	syslog_libbidib(LOG_ERR, "Feedback for action id %d: MSG_SYS_ERROR %s type: %s (0x%02x): %s", 
+	syslog_libbidib(LOG_ERR, "Feedback for action id %d: MSG_SYS_ERROR (board: %s) type: %s (0x%02x): %s", 
 	                action_id, board != NULL ? board->id->str : "UNKNOWN", 
 	                err_name, error_type, fault_name->str);
 	g_string_free(fault_name, TRUE);
@@ -281,9 +281,8 @@ static void bidib_log_boost_stat_error(const uint8_t *const message,
 	} else {
 		g_string_printf(fault_name, "UNKNOWN");
 	}
-	syslog_libbidib(LOG_ERR, "Feedback for action id %d: MSG_BOOST_STAT %s has error: %s", 
-	                action_id, board != NULL ? board->id->str : "UNKNOWN", 
-	                fault_name->str);
+	syslog_libbidib(LOG_ERR, "Feedback for action id %d: MSG_BOOST_STAT (board: %s) has error: %s", 
+	                action_id, board != NULL ? board->id->str : "UNKNOWN", fault_name->str);
 	g_string_free(fault_name, TRUE);
 }
 
@@ -301,9 +300,8 @@ static void bidib_log_boost_stat_okay(const uint8_t *const message,
 	} else {
 		g_string_printf(msg_name, "UNKNOWN");
 	}
-	syslog_libbidib(LOG_INFO, "Feedback for action id %d: MSG_BOOST_STAT %s has state: %s", 
-	                action_id, board != NULL ? board->id->str : "UNKNOWN", 
-	                msg_name->str);
+	syslog_libbidib(LOG_INFO, "Feedback for action id %d: MSG_BOOST_STAT (board: %s) has state: %s", 
+	                action_id, board != NULL ? board->id->str : "UNKNOWN", msg_name->str);
 	g_string_free(msg_name, TRUE);
 }
 

--- a/src/transmission/bidib_transmission_receive.c
+++ b/src/transmission/bidib_transmission_receive.c
@@ -320,7 +320,7 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			break;
 		case MSG_NODE_LOST:
 			// update state
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_INFO,
+			bidib_log_received_message(addr_stack, seqnum, type, LOG_WARNING,
 			                           message, action_id);
 			unique_id.class_id = message[data_index + 2];
 			unique_id.class_id_ext = message[data_index + 3];
@@ -351,7 +351,7 @@ void bidib_handle_received_message(uint8_t *message, uint8_t type,
 			free(message);
 			break;
 		case MSG_STALL:
-			bidib_log_received_message(addr_stack, seqnum, type, LOG_INFO,
+			bidib_log_received_message(addr_stack, seqnum, type, LOG_WARNING,
 			                           message, action_id);
 			bidib_node_update_stall(addr_stack, message[message[0]]);
 			free(message);

--- a/src/transmission/bidib_transmission_receive.c
+++ b/src/transmission/bidib_transmission_receive.c
@@ -241,8 +241,13 @@ static void bidib_log_sys_error(const uint8_t *const message,
 		
 		switch (error_type) {
 			case (BIDIB_ERR_SEQUENCE):
-				g_string_printf(fault_name, "Expected MSG_NUM %d not %d", 
-				                message[data_index + 1], message[data_index + 2]);
+				if (data_index + 2 <= message[0]) {
+					// Error message contains information on actually received seq num
+					g_string_printf(fault_name, "Expected MSG_NUM %d not %d", 
+					                message[data_index + 1], message[data_index + 2]);
+				} else {
+					g_string_printf(fault_name, "Expected MSG_NUM %d", message[data_index + 1]);
+				}
 				break;
 			case (BIDIB_ERR_BUS):
 				g_string_printf(fault_name, "%s", 

--- a/src/transmission/bidib_transmission_send.c
+++ b/src/transmission/bidib_transmission_send.c
@@ -201,7 +201,8 @@ static void bidib_buffer_message(uint8_t seqnum, uint8_t type,
 	bidib_extract_address(message, addr);
 	bidib_log_send_message(type, addr, seqnum, message, action_id);
 	if (bidib_node_try_send(addr, type, message, action_id)) {
-		// Put in buffer
+		// Node is ready -> Put in send buffer
+		// If node is not ready, the node enqueues the message so nothing else to do here.
 		bidib_add_to_buffer(message);
 	}
 }

--- a/src/transmission/bidib_transmission_send.c
+++ b/src/transmission/bidib_transmission_send.c
@@ -192,7 +192,7 @@ static void bidib_log_send_message(uint8_t message_type, const uint8_t *const ad
 	                bidib_message_string_mapping[message_type], message_type, action_id);
 	char hex_string[(message[0] + 1) * 5];
 	bidib_build_message_hex_string(message, hex_string);
-	syslog_libbidib(LOG_DEBUG, "Message bytes: %s", hex_string);
+	syslog_libbidib(LOG_DEBUG, "Message bytes to send: %s", hex_string);
 }
 
 static void bidib_buffer_message(uint8_t seqnum, uint8_t type,

--- a/src/transmission/bidib_transmission_util.c
+++ b/src/transmission/bidib_transmission_util.c
@@ -73,6 +73,7 @@ int bidib_first_data_byte_index(const uint8_t *const message) {
 			return i + 3;
 		}
 	}
+	syslog_libbidib(LOG_WARNING, "bidib_first_data_byte_index - first data byte position not found");
 	return -1;
 }
 


### PR DESCRIPTION
closes #46 
As per issue #46, starting the SWTbahn-Full (via swtbahn-cli) causes the GBMmaster board to stall.    
There is a mechanism for avoiding this, namely the limit for the response queue - we only send a message if the expected response doesn't cause too much work to queue up on the board side of things (48 byte limit, cf. [bidib.org/protokoll/bidib_general_e.html](https://bidib.org/protokoll/bidib_general_e.html) 3.4 (3).).    
However, I think that due to issue #25, we do not count the size of the second response for the point-setting commands, and thus we cause an overload.

The fix is relatively easy - introduce a few more cache flushes and delays during the startup phase, such that the board is not stressed too much. Note that I think I would keep the delays even if #25 is fixed, because it doesnt cause any new issues and reduces power spikes (less points switched at the same time).   
The time needed for startup is now approx. 5.2 seconds, previously it was 4.4 seconds. I think this should be fine.

When working on the fix, I took the liberty to adjust some log messages and log levels. The log during startup should now be easier to read and easier to debug. Furthermore, I added a small workaround for an error we always got during startup, but which wasn't problematic (unexpected sequence number) - see `src/state/bidib_state.c - bidib_state_query_nodetab`. 