### PR TITLE
Fix startup crash invalid free

### DIFF
--- a/src/highlevel/bidib_highlevel_util.c
+++ b/src/highlevel/bidib_highlevel_util.c
@@ -227,8 +227,10 @@ void bidib_stop(void) {
 		usleep(300000); // 0.3s
 		bidib_set_track_output_state_all(BIDIB_CS_OFF);
 		bidib_flush();
-		bidib_running = false;
+		// leave some time to receive/process any remaining booster status updates
+		// such that they do not show up unexpectedly if bidib is started again soon.
 		sleep(1); // 1s
+		bidib_running = false;
 		syslog_libbidib(LOG_NOTICE, "libbidib stopping: waiting for threads to join");
 		if (bidib_receiver_thread != 0) {
 			pthread_join(bidib_receiver_thread, NULL);

--- a/src/highlevel/bidib_highlevel_util.c
+++ b/src/highlevel/bidib_highlevel_util.c
@@ -218,8 +218,11 @@ int bidib_start_serial(const char *device, const char *config_dir, unsigned int 
 void bidib_stop(void) {
 	if (bidib_running) {
 		syslog_libbidib(LOG_NOTICE, "libbidib running and now stopping");
-		// close the track
+		// close the track (causes trains to be stopped)
 		bidib_set_track_output_state_all(BIDIB_CS_SOFTSTOP);
+		bidib_flush();
+		// Tell system to stop sending spontaneous messages (e.g., boost state diagnostics)
+		bidib_send_sys_disable(0);
 		bidib_flush();
 		usleep(300000); // 0.3s
 		bidib_state_reset_train_params();
@@ -227,9 +230,8 @@ void bidib_stop(void) {
 		usleep(300000); // 0.3s
 		bidib_set_track_output_state_all(BIDIB_CS_OFF);
 		bidib_flush();
-		// leave some time to receive/process any remaining booster status updates
-		// such that they do not show up unexpectedly if bidib is started again soon.
-		sleep(1); // 1s
+		// time to process last expected packet (reply to setting track output to off)
+		usleep(300000); // 0.3s
 		bidib_running = false;
 		syslog_libbidib(LOG_NOTICE, "libbidib stopping: waiting for threads to join");
 		if (bidib_receiver_thread != 0) {

--- a/src/highlevel/bidib_highlevel_util.c
+++ b/src/highlevel/bidib_highlevel_util.c
@@ -228,6 +228,7 @@ void bidib_stop(void) {
 		bidib_set_track_output_state_all(BIDIB_CS_OFF);
 		bidib_flush();
 		bidib_running = false;
+		sleep(1); // 1s
 		syslog_libbidib(LOG_NOTICE, "libbidib stopping: waiting for threads to join");
 		if (bidib_receiver_thread != 0) {
 			pthread_join(bidib_receiver_thread, NULL);

--- a/src/transmission/bidib_transmission_receive.c
+++ b/src/transmission/bidib_transmission_receive.c
@@ -93,6 +93,7 @@ static void bidib_message_queue_reset(GQueue *queue) {
 }
 
 void bidib_uplink_queue_reset(bool lock_mutex) {
+	syslog_libbidib(LOG_DEBUG, "Start message queue reset");
 	if (lock_mutex) {
 		pthread_mutex_lock(&bidib_uplink_queue_mutex);
 	}
@@ -107,6 +108,7 @@ void bidib_uplink_queue_reset(bool lock_mutex) {
 
 void bidib_uplink_queue_free(void) {
 	if (!bidib_running) {
+		syslog_libbidib(LOG_DEBUG, "Start message queue free");
 		pthread_mutex_lock(&bidib_uplink_queue_mutex);
 		if (uplink_queue != NULL) {
 			bidib_uplink_queue_reset(false);
@@ -119,6 +121,7 @@ void bidib_uplink_queue_free(void) {
 }
 
 void bidib_uplink_error_queue_reset(bool lock_mutex) {
+	syslog_libbidib(LOG_DEBUG, "Start error message queue reset");
 	if (lock_mutex) {
 		pthread_mutex_lock(&bidib_uplink_error_queue_mutex);
 	}
@@ -133,6 +136,7 @@ void bidib_uplink_error_queue_reset(bool lock_mutex) {
 
 void bidib_uplink_error_queue_free(void) {
 	if (!bidib_running) {
+		syslog_libbidib(LOG_DEBUG, "Start error message queue free");
 		pthread_mutex_lock(&bidib_uplink_error_queue_mutex);
 		if (uplink_error_queue != NULL) {
 			bidib_uplink_error_queue_reset(false);
@@ -145,6 +149,7 @@ void bidib_uplink_error_queue_free(void) {
 }
 
 void bidib_uplink_intern_queue_reset(bool lock_mutex) {
+	syslog_libbidib(LOG_DEBUG, "Start intern message queue reset");
 	if (lock_mutex) {
 		pthread_mutex_lock(&bidib_uplink_intern_queue_mutex);
 	}
@@ -159,6 +164,7 @@ void bidib_uplink_intern_queue_reset(bool lock_mutex) {
 
 void bidib_uplink_intern_queue_free(void) {
 	if (!bidib_running) {
+		syslog_libbidib(LOG_DEBUG, "Start intern message queue free");
 		pthread_mutex_lock(&bidib_uplink_intern_queue_mutex);
 		if (uplink_intern_queue != NULL) {
 			bidib_uplink_intern_queue_reset(false);
@@ -179,6 +185,7 @@ static void bidib_message_queue_add(GQueue *queue, uint8_t *message,
 	memcpy(message_queue_entry->addr, addr_stack, 4);
 	message_queue_entry->message = message;
 	if (g_queue_get_length(queue) == QUEUE_SIZE) {
+		syslog_libbidib(LOG_WARNING, "A queue is full, dropping its oldest element!");
 		bidib_message_queue_free_head(queue);
 	}
 	g_queue_push_tail(queue, message_queue_entry);


### PR DESCRIPTION
Closes #48 - this issue describes the core problem and the fix.

Related changes/improvements in file `src/transmission/bidib_transmission_receive.c`, not described in the linked issue:
- added the mutexes being set in `bidib_set_read_src` to stop my static/dynamic analysis tools from complaining about it, and in some weird scenario this might actually be relevant.
- simplified freeing in `bidib_message_queue_free_head` as the Null-checks don't do/help anything.
- added more logging for queue reset & free to help debugging such a situation.

I tested these changes on the swtbahn-full. With these changes, I was unable to cause the crash I experienced earlier on the master branch. Also, the spontaneous messages still appear as expected whilst the system is running. Everything else worked as expected.